### PR TITLE
Use <see> wherever possible in the docs

### DIFF
--- a/src/Recore.Collections.Generic/ICollectionExtensions.cs
+++ b/src/Recore.Collections.Generic/ICollectionExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Recore.Collections.Generic
 {
     /// <summary>
-    /// Provides additional methods for working with <see cref="ICollection{T}" />.
+    /// Provides additional methods for working with <see cref="ICollection{T}"/>.
     /// </summary>
     public static class ICollectionExtensions
     {

--- a/src/Recore.Collections.Generic/IDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IDictionaryExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Recore.Collections.Generic
 {
     /// <summary>
-    /// Provides additional methods for working with <see cref="IDictionary{TKey, TValue}" />.
+    /// Provides additional methods for working with <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     public static class IDictionaryExtensions
     {

--- a/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Recore.Collections.Generic
 {
     /// <summary>
-    /// Provides additional methods for working with <see cref="IReadOnlyDictionary{TKey, TValue}" />.
+    /// Provides additional methods for working with <see cref="IReadOnlyDictionary{TKey, TValue}"/>.
     /// </summary>
     public static class IReadOnlyDictionaryExtensions
     {

--- a/src/Recore.Collections.Generic/LinkedListExtensions.cs
+++ b/src/Recore.Collections.Generic/LinkedListExtensions.cs
@@ -3,23 +3,23 @@ using System.Collections.Generic;
 namespace Recore.Collections.Generic
 {
     /// <summary>
-    /// Provides additional methods for working with <see cref="LinkedList{T}" />.
+    /// Provides additional methods for working with <see cref="LinkedList{T}"/>.
     /// </summary>
     public static class LinkedListExtensions
     {
         /// <summary>
-        /// Adds a new node with containing the specified value to the end of the <see cref="LinkedList{T}" />.
+        /// Adds a new node with containing the specified value to the end of the <see cref="LinkedList{T}"/>.
         /// </summary>
         /// <remarks>
-        /// This method is the same as <see cref="LinkedList{T}.AddLast(T)" />.
-        /// It is needed to be able to use collection initializer syntax with <see cref="LinkedList{T}" />.
+        /// This method is the same as <see cref="LinkedList{T}.AddLast(T)"/>.
+        /// It is needed to be able to use collection initializer syntax with <see cref="LinkedList{T}"/>.
         /// </remarks>
         public static void Add<T>(this LinkedList<T> linkedList, T item)
             => linkedList.AddLast(item);
 
         /// <summary>
-        /// Adds a new node with containing the specified value to the end of the <see cref="LinkedList{T}" />
-        /// and returns the <see cref="LinkedList{T}" />.
+        /// Adds a new node with containing the specified value to the end of the <see cref="LinkedList{T}"/>
+        /// and returns the <see cref="LinkedList{T}"/>.
         /// </summary>
         public static LinkedList<T> Append<T>(this LinkedList<T> linkedList, T item)
         {

--- a/src/Recore.Collections.Generic/ListExtensions.cs
+++ b/src/Recore.Collections.Generic/ListExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Recore.Collections.Generic
 {
     /// <summary>
-    /// Provides additional methods for working with <see cref="List{T}" />.
+    /// Provides additional methods for working with <see cref="List{T}"/>.
     /// </summary>
     public static class ListExtensions
     {

--- a/src/Recore.Functional/Composer.cs
+++ b/src/Recore.Functional/Composer.cs
@@ -71,7 +71,7 @@ namespace Recore.Functional
         public Func<TValue, TResult> Func { get; }
 
         /// <summary>
-        /// Initializes the <see cref="Composer" /> from a function.
+        /// Initializes the <see cref="Composer"/> from a function.
         /// </summary>
         public Composer(Func<TValue, TResult> func)
         {

--- a/src/Recore.Linq/KeyValuePair.cs
+++ b/src/Recore.Linq/KeyValuePair.cs
@@ -7,7 +7,7 @@ namespace Recore.Linq
     public static partial class Renumerable
     {
         /// <summary>
-        /// Creates a <see cref="Dictionary{TKey, TValue}" /> from a sequence of key-value pairs.
+        /// Creates a <see cref="Dictionary{TKey, TValue}"/> from a sequence of key-value pairs.
         /// </summary>
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
             => source.ToDictionary(x => x.Key, x => x.Value);

--- a/src/Recore.Linq/ToLinkedList.cs
+++ b/src/Recore.Linq/ToLinkedList.cs
@@ -7,16 +7,16 @@ namespace Recore.Linq
     public static partial class Renumerable
     {
         /// <summary>
-        /// Creates a <see cref="LinkedList{T}" /> from an <see cref="IEnumerable{T}" />.
+        /// Creates a <see cref="LinkedList{T}"/> from an <see cref="IEnumerable{T}"/>.
         /// </summary>
         /// <remarks>
         /// Linked lists don't need to be resized when adding elements,
-        /// which can give this method better performance than <see cref="Enumerable.ToList{T}(IEnumerable{T})" /> or <see cref="Enumerable.ToArray{T}(IEnumerable{T})" />.
+        /// which can give this method better performance than <see cref="Enumerable.ToList{T}(IEnumerable{T})"/> or <see cref="Enumerable.ToArray{T}(IEnumerable{T})"/>.
         /// A common case is when you just want to force eager evaluation of a series of
-        /// operations on an <see cref="IEnumerable{T}" />
+        /// operations on an <see cref="IEnumerable{T}"/>
         /// or when you want to cache elements when performing multiple enumerations.
         /// For these cases, you don't need random access to elements, which makes
-        /// <see cref="LinkedList{T}" /> a suitable data structure for storing the elements.
+        /// <see cref="LinkedList{T}"/> a suitable data structure for storing the elements.
         /// </remarks>
         public static LinkedList<TSource> ToLinkedList<TSource>(this IEnumerable<TSource> source)
         {

--- a/src/Recore.Security.Cryptography/SecureCompare.cs
+++ b/src/Recore.Security.Cryptography/SecureCompare.cs
@@ -15,7 +15,7 @@ namespace Recore.Security.Cryptography
         ///
         /// When checking untrusted input against a secret,
         /// using a regular element-by-element equality method
-        /// such as <c>String.Equals</c> is insecure.
+        /// such as <see cref="string.Equals(string)" /> is insecure.
         /// For example, suppose you are checking whether an incoming request's signature
         /// matches what you expect.
         /// In this case, you hash the request payload with your own private key

--- a/src/Recore.Security.Cryptography/SecureCompare.cs
+++ b/src/Recore.Security.Cryptography/SecureCompare.cs
@@ -15,7 +15,7 @@ namespace Recore.Security.Cryptography
         ///
         /// When checking untrusted input against a secret,
         /// using a regular element-by-element equality method
-        /// such as <see cref="string.Equals(string)" /> is insecure.
+        /// such as <see cref="string.Equals(string)"/> is insecure.
         /// For example, suppose you are checking whether an incoming request's signature
         /// matches what you expect.
         /// In this case, you hash the request payload with your own private key

--- a/src/Recore.Text/StringUtil.cs
+++ b/src/Recore.Text/StringUtil.cs
@@ -10,7 +10,7 @@ namespace Recore.Text
     {
         /// <summary>
         /// Concatenates a sequence of strings into a single string
-        /// where each input string is separated by <see cref="Environment.NewLine" />.
+        /// where each input string is separated by <see cref="Environment.NewLine"/>.
         /// </summary>
         public static string JoinLines(IEnumerable<string> lines)
         {
@@ -24,7 +24,7 @@ namespace Recore.Text
 
         /// <summary>
         /// Concatenates a variable number of string arguments into a single string
-        /// where each input string is separated by <see cref="Environment.NewLine" />.
+        /// where each input string is separated by <see cref="Environment.NewLine"/>.
         /// </summary>
         public static string JoinLines(params string[] lines)
             => JoinLines((IEnumerable<string>)lines);

--- a/src/Recore.Threading.Tasks/TaskExtensions.cs
+++ b/src/Recore.Threading.Tasks/TaskExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Recore.Threading.Tasks
@@ -13,8 +14,8 @@ namespace Recore.Threading.Tasks
         /// <remarks>
         /// If <paramref name="task"/> is terminated by an exception, that exception
         /// will be rethrown in the current context.
-        /// Unlike <c>Task.Wait</c>, that exception will be of its original type,
-        /// not <c>AggregateException</c>.
+        /// Unlike <see cref="Task.Wait()" />, that exception will be of its original type,
+        /// not <see cref="AggregateException" />.
         /// It will also preserve its original stack trace.
         /// This exception-throwing behavior is the same as if you had used <c>await</c>.
         /// Note that it is still possible to deadlock with this method.
@@ -28,8 +29,8 @@ namespace Recore.Threading.Tasks
         /// <remarks>
         /// If <paramref name="task"/> is terminated by an exception, that exception
         /// will be rethrown in the current context.
-        /// Unlike <c>Task&lt;T&gt;.Result</c>, that exception will be of its original type,
-        /// not <c>AggregateException</c>.
+        /// Unlike <see cref="Task{TResult}.Result" />, that exception will be of its original type,
+        /// not <see cref="AggregateException" />.
         /// It will also preserve its original stack trace.
         /// This exception-throwing behavior is the same as if you had used <c>await</c>.
         /// Note that it is still possible to deadlock with this method.

--- a/src/Recore.Threading.Tasks/TaskExtensions.cs
+++ b/src/Recore.Threading.Tasks/TaskExtensions.cs
@@ -14,8 +14,8 @@ namespace Recore.Threading.Tasks
         /// <remarks>
         /// If <paramref name="task"/> is terminated by an exception, that exception
         /// will be rethrown in the current context.
-        /// Unlike <see cref="Task.Wait()" />, that exception will be of its original type,
-        /// not <see cref="AggregateException" />.
+        /// Unlike <see cref="Task.Wait()"/>, that exception will be of its original type,
+        /// not <see cref="AggregateException"/>.
         /// It will also preserve its original stack trace.
         /// This exception-throwing behavior is the same as if you had used <c>await</c>.
         /// Note that it is still possible to deadlock with this method.
@@ -29,8 +29,8 @@ namespace Recore.Threading.Tasks
         /// <remarks>
         /// If <paramref name="task"/> is terminated by an exception, that exception
         /// will be rethrown in the current context.
-        /// Unlike <see cref="Task{TResult}.Result" />, that exception will be of its original type,
-        /// not <see cref="AggregateException" />.
+        /// Unlike <see cref="Task{TResult}.Result"/>, that exception will be of its original type,
+        /// not <see cref="AggregateException"/>.
         /// It will also preserve its original stack trace.
         /// This exception-throwing behavior is the same as if you had used <c>await</c>.
         /// Note that it is still possible to deadlock with this method.

--- a/src/Recore/Defer.cs
+++ b/src/Recore/Defer.cs
@@ -9,7 +9,7 @@ namespace Recore
     /// Not thread-safe.
     /// Concurrent calls to dispose the object may result in the action being invoked
     /// multiple times.
-    /// However, synchronous calls to <see cref="Dispose" /> are idempotent.
+    /// However, synchronous calls to <see cref="Dispose"/> are idempotent.
     /// If an instance of this type is created and never disposed, the callback will not be called.
     /// By design, the callback is not called from the finalizer, which would happen non-determinstically.
     /// </remarks>

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -13,17 +13,17 @@ namespace Recore
         private readonly TRight right;
 
         /// <summary>
-        /// Indicates whether the value is of type <typeparamref name="TLeft"/>.
+        /// Indicates whether the value is of type <typeparamref name="TLeft" />.
         /// </summary>
         public bool IsLeft { get; }
 
         /// <summary>
-        /// Indicates whether the value is of type <typeparamref name="TRight"/>.
+        /// Indicates whether the value is of type <typeparamref name="TRight" />.
         /// </summary>
         public bool IsRight => !IsLeft;
 
         /// <summary>
-        /// Constructs an instance of the type from a value of <typeparamref name="TLeft"/>.
+        /// Constructs an instance of the type from a value of <typeparamref name="TLeft" />.
         /// </summary>
         public Either(TLeft left)
         {
@@ -38,7 +38,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Constructs an instance of the type from a value of <typeparamref name="TRight"/>.
+        /// Constructs an instance of the type from a value of <typeparamref name="TRight" />.
         /// </summary>
         public Either(TRight right)
         {
@@ -103,8 +103,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Converts <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
-        /// to <c cref="Optional{TLeft}">Optional&lt;TLeft&gt;</c>
+        /// Converts <see cref="Either{TLeft, TRight}" /> to <see cref="Optional{TLeft}" />.
         /// </summary>
         public Optional<TLeft> GetLeft()
             => Switch(
@@ -112,8 +111,7 @@ namespace Recore
                 right => Optional<TLeft>.Empty);
 
         /// <summary>
-        /// Converts <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
-        /// to <c cref="Optional{TRight}">Optional&lt;TRight&gt;</c>
+        /// Converts <see cref="Either{TLeft, TRight}" /> to <see cref="Optional{TRight}" />.
         /// </summary>
         public Optional<TRight> GetRight()
             => Switch(
@@ -121,7 +119,7 @@ namespace Recore
                 Optional.Of);
 
         /// <summary>
-        /// Maps a function over the <c cref="Either{TLeft, TRight}">Either</c> only if the value is an instance of <c>TLeft</c>.
+        /// Maps a function over the <see cref="Either{TLeft, TRight}" /> only if the value is an instance of <typeparamref name="TLeft" />.
         /// </summary>
         public Either<TResult, TRight> OnLeft<TResult>(Func<TLeft, TResult> onLeft)
             => Switch(
@@ -129,7 +127,7 @@ namespace Recore
                 right => new Either<TResult, TRight>(right));
 
         /// <summary>
-        /// Maps a function over the <c cref="Either{TLeft, TRight}">Either</c> only if the value is an instance of <c>TRight</c>.
+        /// Maps a function over the <see cref="Either{TLeft, TRight}" /> only if the value is an instance of <typeparamref name="TRight" />.
         /// </summary>
         public Either<TLeft, TResult> OnRight<TResult>(Func<TRight, TResult> onRight)
             => Switch(
@@ -137,7 +135,7 @@ namespace Recore
                 right => new Either<TLeft, TResult>(onRight(right)));
 
         /// <summary>
-        /// Takes an action only if the value is an instance of <typeparamref name="TLeft"/>.
+        /// Takes an action only if the value is an instance of <typeparamref name="TLeft" />.
         /// </summary>
         public void IfLeft(Action<TLeft> onLeft)
             => Switch(
@@ -145,7 +143,7 @@ namespace Recore
                 right => { });
 
         /// <summary>
-        /// Takes an action only if the value is an instance of <typeparamref name="TRight"/>.
+        /// Takes an action only if the value is an instance of <typeparamref name="TRight" />.
         /// </summary>
         public void IfRight(Action<TRight> onRight)
             => Switch(
@@ -153,8 +151,8 @@ namespace Recore
                 onRight);
 
         /// <summary>
-        /// Converts this <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
-        /// to an <c cref="Either{TRight, TLeft}">Either&lt;TRight, TLeft&gt;</c>.
+        /// Converts this <see cref="Either{TLeft, TRight}" />
+        /// to an <see cref="Either{TRight, TLeft}" />
         /// </summary>
         public Either<TRight, TLeft> Swap()
             => Switch(
@@ -170,11 +168,11 @@ namespace Recore
                 right => right.ToString());
 
         /// <summary>
-        /// Compares this <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
+        /// Compares this <see cref="Either{TLeft, TRight}" />
         /// to another object for equality.
         /// </summary>
         /// <remarks>
-        /// Two <c>Either</c>s are equal only if they have the same type parameters in the same order.
+        /// Two <see cref="Either{TLeft, TRight}" />s are equal only if they have the same type parameters in the same order.
         /// For example, an <c>Either&lt;int, string&gt;</c> and an <c>Either&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
@@ -183,7 +181,7 @@ namespace Recore
             && this.Equals((Either<TLeft, TRight>)obj);
 
         /// <summary>
-        /// Compares two instances of <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
+        /// Compares two instances of <see cref="Either{TLeft, TRight}" />
         /// for equality.
         /// </summary>
         /// <remarks>
@@ -211,30 +209,30 @@ namespace Recore
                 right => right.GetHashCode());
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
+        /// Determines whether two instances of <see cref="Either{TLeft, TRight}" />
         /// have the same value.
         /// </summary>
         public static bool operator ==(Either<TLeft, TRight> lhs, Either<TLeft, TRight> rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>
+        /// Determines whether two instances of <see cref="Either{TLeft, TRight}" />
         /// have the same value.
         /// </summary>
         public static bool operator !=(Either<TLeft, TRight> lhs, Either<TLeft, TRight> rhs) => !Equals(lhs, rhs);
 
         /// <summary>
-        /// Converts an instance of a type to an <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>.
+        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}" />.
         /// </summary>
         public static implicit operator Either<TLeft, TRight>(TLeft left) => new Either<TLeft, TRight>(left);
 
         /// <summary>
-        /// Converts an instance of a type to an <c cref="Either{TLeft, TRight}">Either&lt;TLeft, TRight&gt;</c>.
+        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}" />.
         /// </summary>
         public static implicit operator Either<TLeft, TRight>(TRight right) => new Either<TLeft, TRight>(right);
     }
 
     /// <summary>
-    /// Provides additional methods for <c>Either</c>.
+    /// Provides additional methods for <see cref="Either{TLeft, TRight}" />.
     /// </summary>
     public static class Either
     {

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -13,17 +13,17 @@ namespace Recore
         private readonly TRight right;
 
         /// <summary>
-        /// Indicates whether the value is of type <typeparamref name="TLeft" />.
+        /// Indicates whether the value is of type <typeparamref name="TLeft"/>.
         /// </summary>
         public bool IsLeft { get; }
 
         /// <summary>
-        /// Indicates whether the value is of type <typeparamref name="TRight" />.
+        /// Indicates whether the value is of type <typeparamref name="TRight"/>.
         /// </summary>
         public bool IsRight => !IsLeft;
 
         /// <summary>
-        /// Constructs an instance of the type from a value of <typeparamref name="TLeft" />.
+        /// Constructs an instance of the type from a value of <typeparamref name="TLeft"/>.
         /// </summary>
         public Either(TLeft left)
         {
@@ -38,7 +38,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Constructs an instance of the type from a value of <typeparamref name="TRight" />.
+        /// Constructs an instance of the type from a value of <typeparamref name="TRight"/>.
         /// </summary>
         public Either(TRight right)
         {
@@ -103,7 +103,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}" /> to <see cref="Optional{TLeft}" />.
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <see cref="Optional{TLeft}"/>.
         /// </summary>
         public Optional<TLeft> GetLeft()
             => Switch(
@@ -111,7 +111,7 @@ namespace Recore
                 right => Optional<TLeft>.Empty);
 
         /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}" /> to <see cref="Optional{TRight}" />.
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <see cref="Optional{TRight}"/>.
         /// </summary>
         public Optional<TRight> GetRight()
             => Switch(
@@ -119,7 +119,7 @@ namespace Recore
                 Optional.Of);
 
         /// <summary>
-        /// Maps a function over the <see cref="Either{TLeft, TRight}" /> only if the value is an instance of <typeparamref name="TLeft" />.
+        /// Maps a function over the <see cref="Either{TLeft, TRight}"/> only if the value is an instance of <typeparamref name="TLeft"/>.
         /// </summary>
         public Either<TResult, TRight> OnLeft<TResult>(Func<TLeft, TResult> onLeft)
             => Switch(
@@ -127,7 +127,7 @@ namespace Recore
                 right => new Either<TResult, TRight>(right));
 
         /// <summary>
-        /// Maps a function over the <see cref="Either{TLeft, TRight}" /> only if the value is an instance of <typeparamref name="TRight" />.
+        /// Maps a function over the <see cref="Either{TLeft, TRight}"/> only if the value is an instance of <typeparamref name="TRight"/>.
         /// </summary>
         public Either<TLeft, TResult> OnRight<TResult>(Func<TRight, TResult> onRight)
             => Switch(
@@ -135,7 +135,7 @@ namespace Recore
                 right => new Either<TLeft, TResult>(onRight(right)));
 
         /// <summary>
-        /// Takes an action only if the value is an instance of <typeparamref name="TLeft" />.
+        /// Takes an action only if the value is an instance of <typeparamref name="TLeft"/>.
         /// </summary>
         public void IfLeft(Action<TLeft> onLeft)
             => Switch(
@@ -143,7 +143,7 @@ namespace Recore
                 right => { });
 
         /// <summary>
-        /// Takes an action only if the value is an instance of <typeparamref name="TRight" />.
+        /// Takes an action only if the value is an instance of <typeparamref name="TRight"/>.
         /// </summary>
         public void IfRight(Action<TRight> onRight)
             => Switch(
@@ -151,8 +151,8 @@ namespace Recore
                 onRight);
 
         /// <summary>
-        /// Converts this <see cref="Either{TLeft, TRight}" />
-        /// to an <see cref="Either{TRight, TLeft}" />
+        /// Converts this <see cref="Either{TLeft, TRight}"/>
+        /// to an <see cref="Either{TRight, TLeft}"/>
         /// </summary>
         public Either<TRight, TLeft> Swap()
             => Switch(
@@ -168,11 +168,11 @@ namespace Recore
                 right => right.ToString());
 
         /// <summary>
-        /// Compares this <see cref="Either{TLeft, TRight}" />
+        /// Compares this <see cref="Either{TLeft, TRight}"/>
         /// to another object for equality.
         /// </summary>
         /// <remarks>
-        /// Two <see cref="Either{TLeft, TRight}" />s are equal only if they have the same type parameters in the same order.
+        /// Two <see cref="Either{TLeft, TRight}"/>s are equal only if they have the same type parameters in the same order.
         /// For example, an <c>Either&lt;int, string&gt;</c> and an <c>Either&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
@@ -181,7 +181,7 @@ namespace Recore
             && this.Equals((Either<TLeft, TRight>)obj);
 
         /// <summary>
-        /// Compares two instances of <see cref="Either{TLeft, TRight}" />
+        /// Compares two instances of <see cref="Either{TLeft, TRight}"/>
         /// for equality.
         /// </summary>
         /// <remarks>
@@ -209,30 +209,30 @@ namespace Recore
                 right => right.GetHashCode());
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Either{TLeft, TRight}" />
+        /// Determines whether two instances of <see cref="Either{TLeft, TRight}"/>
         /// have the same value.
         /// </summary>
         public static bool operator ==(Either<TLeft, TRight> lhs, Either<TLeft, TRight> rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Either{TLeft, TRight}" />
+        /// Determines whether two instances of <see cref="Either{TLeft, TRight}"/>
         /// have the same value.
         /// </summary>
         public static bool operator !=(Either<TLeft, TRight> lhs, Either<TLeft, TRight> rhs) => !Equals(lhs, rhs);
 
         /// <summary>
-        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}" />.
+        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}"/>.
         /// </summary>
         public static implicit operator Either<TLeft, TRight>(TLeft left) => new Either<TLeft, TRight>(left);
 
         /// <summary>
-        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}" />.
+        /// Converts an instance of a type to an <see cref="Either{TLeft, TRight}"/>.
         /// </summary>
         public static implicit operator Either<TLeft, TRight>(TRight right) => new Either<TLeft, TRight>(right);
     }
 
     /// <summary>
-    /// Provides additional methods for <see cref="Either{TLeft, TRight}" />.
+    /// Provides additional methods for <see cref="Either{TLeft, TRight}"/>.
     /// </summary>
     public static class Either
     {

--- a/src/Recore/Hasher.cs
+++ b/src/Recore/Hasher.cs
@@ -10,8 +10,9 @@ namespace Recore
         /// </summary>
         /// <remarks>
         /// This is useful for computing the hash code for a type from the hash codes of all its members.
-        /// It is superseded in .NET Core 3.0 by the <c>System.HashCode</c> type.
+        /// It is superseded in .NET Standard 2.1 by the <c>System.HashCode</c> type.
         /// </remarks>
+        // TODO .NET STandard 2.1 use <see>
         public static int GetHashCode(int seed1=17, int seed2=23, int nullHash = 0, params object[] fields)
         {
             unchecked

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -16,15 +16,15 @@ namespace Recore
         private readonly T value;
 
         /// <summary>
-        /// Indicates whether the <see cref="Optional{T}" /> was created with a value.
+        /// Indicates whether the <see cref="Optional{T}"/> was created with a value.
         /// </summary>
         public bool HasValue { get; }
 
         /// <summary>
-        /// Creates an <see cref="Optional{T}" /> with a value.
+        /// Creates an <see cref="Optional{T}"/> with a value.
         /// </summary>
         /// <remarks>
-        /// If <c>null</c> is passed for <paramref name="value"/>, then the <see cref="Optional{T}" />
+        /// If <c>null</c> is passed for <paramref name="value"/>, then the <see cref="Optional{T}"/>
         /// is considered empty.
         /// </remarks>
         public Optional(T value)
@@ -34,20 +34,20 @@ namespace Recore
         }
 
         /// <summary>
-        /// Creates an <see cref="Optional{T}" /> without a value.
+        /// Creates an <see cref="Optional{T}"/> without a value.
         /// </summary>
         /// <remarks>
-        /// While an empty <see cref="Optional{T}" /> can also be created by calling the default constructor
+        /// While an empty <see cref="Optional{T}"/> can also be created by calling the default constructor
         /// or passing <c>null</c> to the constructor,
-        /// <see cref="Empty" /> is more expressive, making the absence of a value more obvious.
+        /// <see cref="Empty"/> is more expressive, making the absence of a value more obvious.
         /// </remarks>
         public static Optional<T> Empty => new Optional<T>();
 
         /// <summary>
-        /// Chooses a function to call depending on whether the <see cref="Optional{T}" /> has a value.
+        /// Chooses a function to call depending on whether the <see cref="Optional{T}"/> has a value.
         /// </summary>
-        /// <param name="onValue">Called when the <see cref="Optional{T}" /> has a value.</param>
-        /// <param name="onEmpty">Called when the <see cref="Optional{T}" /> does not have a value.</param>
+        /// <param name="onValue">Called when the <see cref="Optional{T}"/> has a value.</param>
+        /// <param name="onEmpty">Called when the <see cref="Optional{T}"/> does not have a value.</param>
         /// <returns>Result of the function that was called.</returns>
         public U Switch<U>(Func<T, U> onValue, Func<U> onEmpty)
         {
@@ -72,10 +72,10 @@ namespace Recore
         }
 
         /// <summary>
-        /// Chooses an action to take depending on whether the <see cref="Optional{T}" /> has a value.
+        /// Chooses an action to take depending on whether the <see cref="Optional{T}"/> has a value.
         /// </summary>
-        /// <param name="onValue">Called when the <see cref="Optional{T}" /> has a value.</param>
-        /// <param name="onEmpty">Called when the <see cref="Optional{T}" /> does not have a value.</param>
+        /// <param name="onValue">Called when the <see cref="Optional{T}"/> has a value.</param>
+        /// <param name="onEmpty">Called when the <see cref="Optional{T}"/> does not have a value.</param>
         public void Switch(Action<T> onValue, Action onEmpty)
         {
             if (onValue == null)
@@ -99,7 +99,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Extracts the value with a fallback if the <see cref="Optional{T}" /> is empty.
+        /// Extracts the value with a fallback if the <see cref="Optional{T}"/> is empty.
         /// </summary>
         public T ValueOr(T fallback)
             => Switch(
@@ -107,7 +107,7 @@ namespace Recore
                 () => fallback);
 
         /// <summary>
-        /// Maps a function over the <see cref="Optional{T}" />'s value, or propagates <see cref="Optional{T}.Empty" />.
+        /// Maps a function over the <see cref="Optional{T}"/>'s value, or propagates <see cref="Optional{T}.Empty"/>.
         /// </summary>
         public Optional<U> OnValue<U>(Func<T, U> f)
             => Switch(
@@ -115,7 +115,7 @@ namespace Recore
                 () => Optional<U>.Empty);
 
         /// <summary>
-        /// Takes an action only if the <see cref="Optional{T}" /> has a value.
+        /// Takes an action only if the <see cref="Optional{T}"/> has a value.
         /// </summary>
         public void IfValue(Action<T> onValue)
             => Switch(
@@ -123,7 +123,7 @@ namespace Recore
                 () => { });
 
         /// <summary>
-        /// Takes an action only if the <see cref="Optional{T}" /> is empty.
+        /// Takes an action only if the <see cref="Optional{T}"/> is empty.
         /// </summary>
         public void IfEmpty(Action onEmpty)
             => Switch(
@@ -131,13 +131,13 @@ namespace Recore
                 onEmpty);
 
         /// <summary>
-        /// Chains another <see cref="Optional{T}" />-producing operation onto the result of another.
+        /// Chains another <see cref="Optional{T}"/>-producing operation onto the result of another.
         /// </summary>
         /// <remarks>
         /// This is a monad bind operation.
         /// Conceptually, it is the same as passing <paramref name="f"/> to <c cref="OnValue{U}(Func{T, U})">OnValue</c>
         /// and then "flattening" the <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> into an <c>Optional&lt;<typeparamref name="T"/>&gt;</c>.
-        /// (Note that <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> is not a valid <see cref="Optional{T}" /> because of the
+        /// (Note that <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> is not a valid <see cref="Optional{T}"/> because of the
         /// type constraint <c>where T : class</c>.)
         /// </remarks>
         public Optional<U> Then<U>(Func<T, Optional<U>> f)
@@ -155,7 +155,7 @@ namespace Recore
 
         /// <summary>
         /// Determines whether this instance and another object,
-        /// which must also be an <see cref="Optional{T}" />,
+        /// which must also be an <see cref="Optional{T}"/>,
         /// have the same value.
         /// </summary>
         public override bool Equals(object obj)
@@ -163,7 +163,7 @@ namespace Recore
             && this.Equals((Optional<T>)obj);
 
         /// <summary>
-        /// Determines whether this instance and another <see cref="Optional{T}" />
+        /// Determines whether this instance and another <see cref="Optional{T}"/>
         /// have the same value.
         /// </summary>
         public bool Equals(Optional<T> other)
@@ -237,12 +237,12 @@ namespace Recore
         }
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Optional{T}" /> have the same value.
+        /// Determines whether two instances of <see cref="Optional{T}"/> have the same value.
         /// </summary>
         public static bool operator ==(Optional<T> lhs, Optional<T> rhs) => lhs.Equals(rhs);
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Optional{T}" /> have different values.
+        /// Determines whether two instances of <see cref="Optional{T}"/> have different values.
         /// </summary>
         public static bool operator !=(Optional<T> lhs, Optional<T> rhs) => !lhs.Equals(rhs);
 
@@ -260,7 +260,7 @@ namespace Recore
     }
 
     /// <summary>
-    /// Provides additional methods for <see cref="Optional{T}" />.
+    /// Provides additional methods for <see cref="Optional{T}"/>.
     /// </summary>
     public static class Optional
     {
@@ -269,7 +269,7 @@ namespace Recore
         /// </summary>
         /// <remarks>
         /// This is useful for type inference in some cases where the implicit conversion
-        /// can't be used, such as creating an <see cref="Optional{T}" />
+        /// can't be used, such as creating an <see cref="Optional{T}"/>
         /// and immediately invoking a method.
         /// It can also be passed as a delegate whereas the constructor can't be.
         /// </remarks>
@@ -279,7 +279,7 @@ namespace Recore
         /// Sets an optional value if a condition is true.
         /// </summary>
         /// <remarks>
-        /// This method is useful for converting the <c>TryParse</c> pattern to an <see cref="Optional{T}" /> result.
+        /// This method is useful for converting the <c>TryParse</c> pattern to an <see cref="Optional{T}"/> result.
         /// </remarks>
         public static Optional<T> If<T>(bool condition, T value)
         {
@@ -295,7 +295,7 @@ namespace Recore
 
         /// <summary>
         /// Converts an <c>Optional&lt;Optional&lt;T&gt;&gt;</c>
-        /// to an <see cref="Optional{T}" />.
+        /// to an <see cref="Optional{T}"/>.
         /// </summary>
         public static Optional<T> Flatten<T>(this Optional<Optional<T>> optionalOptional)
             => optionalOptional.Then(x => x);

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -16,15 +16,15 @@ namespace Recore
         private readonly T value;
 
         /// <summary>
-        /// Indicates whether the <c cref="Optional{T}">Optional</c> was created with a value.
+        /// Indicates whether the <see cref="Optional{T}" /> was created with a value.
         /// </summary>
         public bool HasValue { get; }
 
         /// <summary>
-        /// Creates an <c cref="Optional{T}">Optional</c> with a value.
+        /// Creates an <see cref="Optional{T}" /> with a value.
         /// </summary>
         /// <remarks>
-        /// If <c>null</c> is passed for <paramref name="value"/>, then the <c cref="Optional{T}">Optional</c>
+        /// If <c>null</c> is passed for <paramref name="value"/>, then the <see cref="Optional{T}" />
         /// is considered empty.
         /// </remarks>
         public Optional(T value)
@@ -34,20 +34,20 @@ namespace Recore
         }
 
         /// <summary>
-        /// Creates an <c cref="Optional{T}">Optional</c> without a value.
+        /// Creates an <see cref="Optional{T}" /> without a value.
         /// </summary>
         /// <remarks>
-        /// While an empty <c cref="Optional{T}">Optional</c> can also be created by calling the default constructor
+        /// While an empty <see cref="Optional{T}" /> can also be created by calling the default constructor
         /// or passing <c>null</c> to the constructor,
-        /// <c cref="Empty">Empty</c> is more expressive, making the absence of a value more obvious.
+        /// <see cref="Empty" /> is more expressive, making the absence of a value more obvious.
         /// </remarks>
         public static Optional<T> Empty => new Optional<T>();
 
         /// <summary>
-        /// Chooses a function to call depending on whether the <c cref="Optional{T}">Optional</c> has a value.
+        /// Chooses a function to call depending on whether the <see cref="Optional{T}" /> has a value.
         /// </summary>
-        /// <param name="onValue">Called when the <c cref="Optional{T}">Optional</c> has a value.</param>
-        /// <param name="onEmpty">Called when the <c cref="Optional{T}">Optional</c> does not have a value.</param>
+        /// <param name="onValue">Called when the <see cref="Optional{T}" /> has a value.</param>
+        /// <param name="onEmpty">Called when the <see cref="Optional{T}" /> does not have a value.</param>
         /// <returns>Result of the function that was called.</returns>
         public U Switch<U>(Func<T, U> onValue, Func<U> onEmpty)
         {
@@ -72,10 +72,10 @@ namespace Recore
         }
 
         /// <summary>
-        /// Chooses an action to take depending on whether the <c cref="Optional{T}">Optional</c> has a value.
+        /// Chooses an action to take depending on whether the <see cref="Optional{T}" /> has a value.
         /// </summary>
-        /// <param name="onValue">Called when the <c cref="Optional{T}">Optional</c> has a value.</param>
-        /// <param name="onEmpty">Called when the <c cref="Optional{T}">Optional</c> does not have a value.</param>
+        /// <param name="onValue">Called when the <see cref="Optional{T}" /> has a value.</param>
+        /// <param name="onEmpty">Called when the <see cref="Optional{T}" /> does not have a value.</param>
         public void Switch(Action<T> onValue, Action onEmpty)
         {
             if (onValue == null)
@@ -99,7 +99,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Extracts the value with a fallback if the <c cref="Optional{T}">Optional</c> is empty.
+        /// Extracts the value with a fallback if the <see cref="Optional{T}" /> is empty.
         /// </summary>
         public T ValueOr(T fallback)
             => Switch(
@@ -107,7 +107,7 @@ namespace Recore
                 () => fallback);
 
         /// <summary>
-        /// Maps a function over the <c cref="Optional{T}">Optional</c>'s value, or propagates <c cref="Optional{T}.Empty">Empty</c>.
+        /// Maps a function over the <see cref="Optional{T}" />'s value, or propagates <see cref="Optional{T}.Empty" />.
         /// </summary>
         public Optional<U> OnValue<U>(Func<T, U> f)
             => Switch(
@@ -115,7 +115,7 @@ namespace Recore
                 () => Optional<U>.Empty);
 
         /// <summary>
-        /// Takes an action only if the <c cref="Optional{T}">Optional</c> has a value.
+        /// Takes an action only if the <see cref="Optional{T}" /> has a value.
         /// </summary>
         public void IfValue(Action<T> onValue)
             => Switch(
@@ -123,7 +123,7 @@ namespace Recore
                 () => { });
 
         /// <summary>
-        /// Takes an action only if the <c cref="Optional{T}">Optional</c> is empty.
+        /// Takes an action only if the <see cref="Optional{T}" /> is empty.
         /// </summary>
         public void IfEmpty(Action onEmpty)
             => Switch(
@@ -131,13 +131,13 @@ namespace Recore
                 onEmpty);
 
         /// <summary>
-        /// Chains another <c cref="Optional{T}">Optional</c>-producing operation onto the result of another.
+        /// Chains another <see cref="Optional{T}" />-producing operation onto the result of another.
         /// </summary>
         /// <remarks>
         /// This is a monad bind operation.
         /// Conceptually, it is the same as passing <paramref name="f"/> to <c cref="OnValue{U}(Func{T, U})">OnValue</c>
         /// and then "flattening" the <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> into an <c>Optional&lt;<typeparamref name="T"/>&gt;</c>.
-        /// (Note that <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> is not a valid <c cref="Optional{T}">Optional</c> because of the
+        /// (Note that <c>Optionlt;Optional&lt;<typeparamref name="T"/>&gt;&gt;</c> is not a valid <see cref="Optional{T}" /> because of the
         /// type constraint <c>where T : class</c>.)
         /// </remarks>
         public Optional<U> Then<U>(Func<T, Optional<U>> f)
@@ -155,7 +155,7 @@ namespace Recore
 
         /// <summary>
         /// Determines whether this instance and another object,
-        /// which must also be an <c cref="Optional{T}">Optional&lt;T&gt;</c>,
+        /// which must also be an <see cref="Optional{T}" />,
         /// have the same value.
         /// </summary>
         public override bool Equals(object obj)
@@ -163,7 +163,7 @@ namespace Recore
             && this.Equals((Optional<T>)obj);
 
         /// <summary>
-        /// Determines whether this instance and another <c cref="Optional{T}">Optional&lt;T&gt;</c>
+        /// Determines whether this instance and another <see cref="Optional{T}" />
         /// have the same value.
         /// </summary>
         public bool Equals(Optional<T> other)
@@ -237,14 +237,12 @@ namespace Recore
         }
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Optional{T}">Optional&lt;T&gt;</c>
-        /// have the same value.
+        /// Determines whether two instances of <see cref="Optional{T}" /> have the same value.
         /// </summary>
         public static bool operator ==(Optional<T> lhs, Optional<T> rhs) => lhs.Equals(rhs);
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Optional{T}">Optional&lt;T&gt;</c>
-        /// have different values.
+        /// Determines whether two instances of <see cref="Optional{T}" /> have different values.
         /// </summary>
         public static bool operator !=(Optional<T> lhs, Optional<T> rhs) => !lhs.Equals(rhs);
 
@@ -262,7 +260,7 @@ namespace Recore
     }
 
     /// <summary>
-    /// Provides additional methods for <c cref="Optional{T}">Optional&lt;T&gt;</c>.
+    /// Provides additional methods for <see cref="Optional{T}" />.
     /// </summary>
     public static class Optional
     {
@@ -271,7 +269,7 @@ namespace Recore
         /// </summary>
         /// <remarks>
         /// This is useful for type inference in some cases where the implicit conversion
-        /// can't be used, such as creating an <c cref="Optional{T}">Optional&lt;T&gt;</c>
+        /// can't be used, such as creating an <see cref="Optional{T}" />
         /// and immediately invoking a method.
         /// It can also be passed as a delegate whereas the constructor can't be.
         /// </remarks>
@@ -281,7 +279,7 @@ namespace Recore
         /// Sets an optional value if a condition is true.
         /// </summary>
         /// <remarks>
-        /// This method is useful for converting the TryParse pattern to an <c>Optional</c> result.
+        /// This method is useful for converting the <c>TryParse</c> pattern to an <see cref="Optional{T}" /> result.
         /// </remarks>
         public static Optional<T> If<T>(bool condition, T value)
         {
@@ -297,7 +295,7 @@ namespace Recore
 
         /// <summary>
         /// Converts an <c>Optional&lt;Optional&lt;T&gt;&gt;</c>
-        /// to an <c>Optional&lt;T&gt;</c>.
+        /// to an <see cref="Optional{T}" />.
         /// </summary>
         public static Optional<T> Flatten<T>(this Optional<Optional<T>> optionalOptional)
             => optionalOptional.Then(x => x);

--- a/src/Recore/Result.cs
+++ b/src/Recore/Result.cs
@@ -55,21 +55,21 @@ namespace Recore
             => either.Switch(onValue, onError);
 
         /// <summary>
-        /// Converts <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Converts <see cref="Result{TValue, TError}" />
         /// to <c cref="Optional{TValue}">Optional&lt;TValue&gt;</c>
         /// </summary>
         public Optional<TValue> GetValue()
             => either.GetLeft();
 
         /// <summary>
-        /// Converts <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Converts <see cref="Result{TValue, TError}" />
         /// to <c cref="Optional{TError}">Optional&lt;TError&gt;</c>
         /// </summary>
         public Optional<TError> GetError()
             => either.GetRight();
 
         /// <summary>
-        /// Maps a function over the <c cref="Result{TValue, TError}">Result</c> only if the result is successful.
+        /// Maps a function over the <see cref="Result{TValue, TError}" /> only if the result is successful.
         /// </summary>
         public Result<TResult, TError> OnValue<TResult>(Func<TValue, TResult> onValue)
             => Switch(
@@ -77,7 +77,7 @@ namespace Recore
                 Result.Failure<TResult, TError>);
 
         /// <summary>
-        /// Maps a function over the <c cref="Result{TValue, TError}">Result</c> only if the result is failed.
+        /// Maps a function over the <see cref="Result{TValue, TError}" /> only if the result is failed.
         /// </summary>
         public Result<TValue, TResult> OnError<TResult>(Func<TError, TResult> onError)
             => Switch(
@@ -97,7 +97,7 @@ namespace Recore
             => either.IfRight(onError);
 
         /// <summary>
-        /// Chains another <c cref="Result{TValue, TError}">Result</c>-producing operation from another.
+        /// Chains another <see cref="Result{TValue, TError}" />-producing operation from another.
         /// </summary>
         /// <remarks>
         /// This is a monad bind operation.
@@ -116,11 +116,11 @@ namespace Recore
             => either.ToString();
 
         /// <summary>
-        /// Compares this <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Compares this <see cref="Result{TValue, TError}" />
         /// to another object for equality.
         /// </summary>
         /// <remarks>
-        /// Two <c>Result</c>s are equal only if they have the same type parameters in the same order.
+        /// Two <see cref="Result{TValue, TError}" />s are equal only if they have the same type parameters in the same order.
         /// For example, an <c>Result&lt;int, string&gt;</c> and an <c>Result&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
@@ -129,7 +129,7 @@ namespace Recore
             && this.Equals((Result<TValue, TError>)obj);
 
         /// <summary>
-        /// Compares two instances of <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Compares two instances of <see cref="Result{TValue, TError}" />
         /// for equality.
         /// </summary>
         /// <remarks>
@@ -146,30 +146,30 @@ namespace Recore
             => either.GetHashCode();
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Determines whether two instances of <see cref="Result{TValue, TError}" />
         /// have the same value.
         /// </summary>
         public static bool operator ==(Result<TValue, TError> lhs, Result<TValue, TError> rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>
+        /// Determines whether two instances of <see cref="Result{TValue, TError}" />
         /// have the same value.
         /// </summary>
         public static bool operator !=(Result<TValue, TError> lhs, Result<TValue, TError> rhs) => !Equals(lhs, rhs);
 
         /// <summary>
-        /// Converts an instance of a type to an <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>.
+        /// Converts an instance of a type to an <see cref="Result{TValue, TError}" />.
         /// </summary>
         public static implicit operator Result<TValue, TError>(TValue value) => new Result<TValue, TError>(value);
 
         /// <summary>
-        /// Converts an instance of a type to an <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>.
+        /// Converts an instance of a type to an <see cref="Result{TValue, TError}" />.
         /// </summary>
         public static implicit operator Result<TValue, TError>(TError error) => new Result<TValue, TError>(error);
     }
 
     /// <summary>
-    /// Provides additional methods for <c>Result</c>.
+    /// Provides additional methods for <see cref="Result{TValue, TError}" />.
     /// </summary>
     public static class Result
     {
@@ -186,7 +186,7 @@ namespace Recore
             => new Result<TValue, TError>(error);
 
         /// <summary>
-        /// Wraps a function to be executed and converted to <c>Result</c>.
+        /// Wraps a function to be executed and converted to <see cref="Result{TValue, TError}" />.
         /// </summary>
         public sealed class Catcher<TValue>
         {
@@ -229,7 +229,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Suspends a function to be executed by <c cref="Catcher{TValue}.Catch{TException}()">Catcher&lt;TValue&gt;.Catch</c>.
+        /// Suspends a function to be executed by <see cref="Catcher{TValue}.Catch{TException}()" />.
         /// </summary>
         public static Catcher<TValue> Try<TValue>(Func<TValue> func)
         {
@@ -243,7 +243,7 @@ namespace Recore
 
         /// <summary>
         /// Converts a <c cref="Result{TValue, TError}">Result&lt;Result&lt;TValue, TError&gt;, TError&gt;</c>
-        /// to a <c cref="Result{TValue, TError}">Result&lt;TValue, TError&gt;</c>.
+        /// to a <see cref="Result{TValue, TError}" />.
         /// </summary>
         public static Result<TValue, TError> Flatten<TValue, TError>(this Result<Result<TValue, TError>, TError> resultResult)
             => resultResult.Then(x => x);

--- a/src/Recore/Result.cs
+++ b/src/Recore/Result.cs
@@ -55,21 +55,21 @@ namespace Recore
             => either.Switch(onValue, onError);
 
         /// <summary>
-        /// Converts <see cref="Result{TValue, TError}" />
+        /// Converts <see cref="Result{TValue, TError}"/>
         /// to <c cref="Optional{TValue}">Optional&lt;TValue&gt;</c>
         /// </summary>
         public Optional<TValue> GetValue()
             => either.GetLeft();
 
         /// <summary>
-        /// Converts <see cref="Result{TValue, TError}" />
+        /// Converts <see cref="Result{TValue, TError}"/>
         /// to <c cref="Optional{TError}">Optional&lt;TError&gt;</c>
         /// </summary>
         public Optional<TError> GetError()
             => either.GetRight();
 
         /// <summary>
-        /// Maps a function over the <see cref="Result{TValue, TError}" /> only if the result is successful.
+        /// Maps a function over the <see cref="Result{TValue, TError}"/> only if the result is successful.
         /// </summary>
         public Result<TResult, TError> OnValue<TResult>(Func<TValue, TResult> onValue)
             => Switch(
@@ -77,7 +77,7 @@ namespace Recore
                 Result.Failure<TResult, TError>);
 
         /// <summary>
-        /// Maps a function over the <see cref="Result{TValue, TError}" /> only if the result is failed.
+        /// Maps a function over the <see cref="Result{TValue, TError}"/> only if the result is failed.
         /// </summary>
         public Result<TValue, TResult> OnError<TResult>(Func<TError, TResult> onError)
             => Switch(
@@ -97,7 +97,7 @@ namespace Recore
             => either.IfRight(onError);
 
         /// <summary>
-        /// Chains another <see cref="Result{TValue, TError}" />-producing operation from another.
+        /// Chains another <see cref="Result{TValue, TError}"/>-producing operation from another.
         /// </summary>
         /// <remarks>
         /// This is a monad bind operation.
@@ -116,11 +116,11 @@ namespace Recore
             => either.ToString();
 
         /// <summary>
-        /// Compares this <see cref="Result{TValue, TError}" />
+        /// Compares this <see cref="Result{TValue, TError}"/>
         /// to another object for equality.
         /// </summary>
         /// <remarks>
-        /// Two <see cref="Result{TValue, TError}" />s are equal only if they have the same type parameters in the same order.
+        /// Two <see cref="Result{TValue, TError}"/>s are equal only if they have the same type parameters in the same order.
         /// For example, an <c>Result&lt;int, string&gt;</c> and an <c>Result&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
@@ -129,7 +129,7 @@ namespace Recore
             && this.Equals((Result<TValue, TError>)obj);
 
         /// <summary>
-        /// Compares two instances of <see cref="Result{TValue, TError}" />
+        /// Compares two instances of <see cref="Result{TValue, TError}"/>
         /// for equality.
         /// </summary>
         /// <remarks>
@@ -146,30 +146,30 @@ namespace Recore
             => either.GetHashCode();
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Result{TValue, TError}" />
+        /// Determines whether two instances of <see cref="Result{TValue, TError}"/>
         /// have the same value.
         /// </summary>
         public static bool operator ==(Result<TValue, TError> lhs, Result<TValue, TError> rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Result{TValue, TError}" />
+        /// Determines whether two instances of <see cref="Result{TValue, TError}"/>
         /// have the same value.
         /// </summary>
         public static bool operator !=(Result<TValue, TError> lhs, Result<TValue, TError> rhs) => !Equals(lhs, rhs);
 
         /// <summary>
-        /// Converts an instance of a type to an <see cref="Result{TValue, TError}" />.
+        /// Converts an instance of a type to an <see cref="Result{TValue, TError}"/>.
         /// </summary>
         public static implicit operator Result<TValue, TError>(TValue value) => new Result<TValue, TError>(value);
 
         /// <summary>
-        /// Converts an instance of a type to an <see cref="Result{TValue, TError}" />.
+        /// Converts an instance of a type to an <see cref="Result{TValue, TError}"/>.
         /// </summary>
         public static implicit operator Result<TValue, TError>(TError error) => new Result<TValue, TError>(error);
     }
 
     /// <summary>
-    /// Provides additional methods for <see cref="Result{TValue, TError}" />.
+    /// Provides additional methods for <see cref="Result{TValue, TError}"/>.
     /// </summary>
     public static class Result
     {
@@ -186,7 +186,7 @@ namespace Recore
             => new Result<TValue, TError>(error);
 
         /// <summary>
-        /// Wraps a function to be executed and converted to <see cref="Result{TValue, TError}" />.
+        /// Wraps a function to be executed and converted to <see cref="Result{TValue, TError}"/>.
         /// </summary>
         public sealed class Catcher<TValue>
         {
@@ -229,7 +229,7 @@ namespace Recore
         }
 
         /// <summary>
-        /// Suspends a function to be executed by <see cref="Catcher{TValue}.Catch{TException}()" />.
+        /// Suspends a function to be executed by <see cref="Catcher{TValue}.Catch{TException}()"/>.
         /// </summary>
         public static Catcher<TValue> Try<TValue>(Func<TValue> func)
         {
@@ -243,7 +243,7 @@ namespace Recore
 
         /// <summary>
         /// Converts a <c cref="Result{TValue, TError}">Result&lt;Result&lt;TValue, TError&gt;, TError&gt;</c>
-        /// to a <see cref="Result{TValue, TError}" />.
+        /// to a <see cref="Result{TValue, TError}"/>.
         /// </summary>
         public static Result<TValue, TError> Flatten<TValue, TError>(this Result<Result<TValue, TError>, TError> resultResult)
             => resultResult.Then(x => x);

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -8,7 +8,7 @@ namespace Recore
     /// Represents a non-null, non-empty string value where whitespace is not allowed.
     /// </summary>
     /// <remarks>
-    /// This type is meant to feel like a subclass of <see cref="string" />, which is sealed.
+    /// This type is meant to feel like a subclass of <see cref="string"/>, which is sealed.
     /// </remarks>
     public sealed class Token : IEquatable<Token>, IComparable<Token>, IEquatable<string>, IComparable<string>
     {
@@ -16,7 +16,7 @@ namespace Recore
         private readonly string value;
 
         /// <summary>
-        /// Constructs an instance of <see cref="Token" /> from a string value.
+        /// Constructs an instance of <see cref="Token"/> from a string value.
         /// </summary>
         public Token(string value)
         {
@@ -48,7 +48,7 @@ namespace Recore
 
         /// <summary>
         /// Determines whether this instance and another object,
-        /// which must be a <see cref="Token" /> or a <see cref="string" />,
+        /// which must be a <see cref="Token"/> or a <see cref="string"/>,
         /// have the same value.
         /// </summary>
         public override bool Equals(object obj)
@@ -68,25 +68,25 @@ namespace Recore
         }
 
         /// <summary>
-        /// Determines whether this instance and another <see cref="Token" />
+        /// Determines whether this instance and another <see cref="Token"/>
         /// have the same value.
         /// </summary>
         public bool Equals(Token other) => value == other.value;
 
         /// <summary>
-        /// Determines whether this instance and a <see cref="string" />
+        /// Determines whether this instance and a <see cref="string"/>
         /// have the same value.
         /// </summary>
         public bool Equals(string other) => value.Equals(other);
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Token" />
+        /// Determines whether two instances of <see cref="Token"/>
         /// have the same value.
         /// </summary>
         public static bool operator ==(Token lhs, Token rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <see cref="Token" />
+        /// Determines whether two instances of <see cref="Token"/>
         /// have different values.
         /// </summary>
         public static bool operator !=(Token lhs, Token rhs) => !Equals(lhs, rhs);
@@ -97,14 +97,14 @@ namespace Recore
         public override int GetHashCode() => value.GetHashCode();
 
         /// <summary>
-        /// Compares this instance with a specified <see cref="Token" /> object
+        /// Compares this instance with a specified <see cref="Token"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
         public int CompareTo(Token other) => value.CompareTo(other.value);
 
         /// <summary>
-        /// Compares this instance with a specified <see cref="string" /> object
+        /// Compares this instance with a specified <see cref="string"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
@@ -130,7 +130,7 @@ namespace Recore
         /// <remarks>
         /// While a particular string may consist of tokens delimited by some other character or string,
         /// this method does not provide an option for this by design.
-        /// This is consistent with the <see cref="Token" /> type itself,
+        /// This is consistent with the <see cref="Token"/> type itself,
         /// which does not check for any characters besides whitespace.
         /// </remarks>
         public static Token[] Tokenize(this string str)

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -8,7 +8,7 @@ namespace Recore
     /// Represents a non-null, non-empty string value where whitespace is not allowed.
     /// </summary>
     /// <remarks>
-    /// This type is meant to feel like a subclass of <c>String</c>, which is sealed.
+    /// This type is meant to feel like a subclass of <see cref="string" />, which is sealed.
     /// </remarks>
     public sealed class Token : IEquatable<Token>, IComparable<Token>, IEquatable<string>, IComparable<string>
     {
@@ -16,7 +16,7 @@ namespace Recore
         private readonly string value;
 
         /// <summary>
-        /// Constructs an instance of <c cref="Token">Token</c> from a string value.
+        /// Constructs an instance of <see cref="Token" /> from a string value.
         /// </summary>
         public Token(string value)
         {
@@ -48,7 +48,7 @@ namespace Recore
 
         /// <summary>
         /// Determines whether this instance and another object,
-        /// which must be a <c cref="Token">Token</c> or a <c>String</c>,
+        /// which must be a <see cref="Token" /> or a <see cref="string" />,
         /// have the same value.
         /// </summary>
         public override bool Equals(object obj)
@@ -68,25 +68,25 @@ namespace Recore
         }
 
         /// <summary>
-        /// Determines whether this instance and another <c cref="Token">Token</c>
+        /// Determines whether this instance and another <see cref="Token" />
         /// have the same value.
         /// </summary>
         public bool Equals(Token other) => value == other.value;
 
         /// <summary>
-        /// Determines whether this instance and a <c>String</c>
+        /// Determines whether this instance and a <see cref="string" />
         /// have the same value.
         /// </summary>
         public bool Equals(string other) => value.Equals(other);
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Token">Token</c>
+        /// Determines whether two instances of <see cref="Token" />
         /// have the same value.
         /// </summary>
         public static bool operator ==(Token lhs, Token rhs) => Equals(lhs, rhs);
 
         /// <summary>
-        /// Determines whether two instances of <c cref="Token">Token</c>
+        /// Determines whether two instances of <see cref="Token" />
         /// have different values.
         /// </summary>
         public static bool operator !=(Token lhs, Token rhs) => !Equals(lhs, rhs);
@@ -97,14 +97,14 @@ namespace Recore
         public override int GetHashCode() => value.GetHashCode();
 
         /// <summary>
-        /// Compares this instance with a specified <c>Token</c> object
+        /// Compares this instance with a specified <see cref="Token" /> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
         public int CompareTo(Token other) => value.CompareTo(other.value);
 
         /// <summary>
-        /// Compares this instance with a specified <c>String</c> object
+        /// Compares this instance with a specified <see cref="string" /> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
@@ -130,7 +130,7 @@ namespace Recore
         /// <remarks>
         /// While a particular string may consist of tokens delimited by some other character or string,
         /// this method does not provide an option for this by design.
-        /// This is consistent with the <c cref="Token">Token</c> type itself,
+        /// This is consistent with the <see cref="Token" /> type itself,
         /// which does not check for any characters besides whitespace.
         /// </remarks>
         public static Token[] Tokenize(this string str)

--- a/src/Recore/Unit.cs
+++ b/src/Recore/Unit.cs
@@ -6,22 +6,22 @@ namespace Recore
     /// A type with only one value.
     /// </summary>
     /// <remarks>
-    /// Whereas <see cref="void" />is a type with no values,
-    /// <see cref="Unit" /> is a type with one value.
+    /// Whereas <see cref="void"/>is a type with no values,
+    /// <see cref="Unit"/> is a type with one value.
     /// It is useful when designing generic types or methods so that a non-generic version
     /// does not have to be provided.
     /// It is also useful for fluent interfaces (such as LINQ)
-    /// so that a chain of method calls does not have to be broken by a <see cref="void" />-returning call.
+    /// so that a chain of method calls does not have to be broken by a <see cref="void"/>-returning call.
     /// </remarks>
     public readonly struct Unit : IEquatable<Unit>
     {
         /// <summary>
-        /// A singleton <see cref="Unit" /> value.
+        /// A singleton <see cref="Unit"/> value.
         /// </summary>
         public static Unit Value { get; } = new Unit();
 
         /// <summary>
-        /// Converts a return type of <see cref="void" /> to a return type of <see cref="Unit" />.
+        /// Converts a return type of <see cref="void"/> to a return type of <see cref="Unit"/>.
         /// </summary>
         public static Func<Unit> Close(Action action)
         {

--- a/src/Recore/Unit.cs
+++ b/src/Recore/Unit.cs
@@ -6,12 +6,12 @@ namespace Recore
     /// A type with only one value.
     /// </summary>
     /// <remarks>
-    /// Whereas <see cref="System.Void" />is a type with no values,
+    /// Whereas <see cref="void" />is a type with no values,
     /// <see cref="Unit" /> is a type with one value.
     /// It is useful when designing generic types or methods so that a non-generic version
     /// does not have to be provided.
     /// It is also useful for fluent interfaces (such as LINQ)
-    /// so that a chain of method calls does not have to be broken by a <c>void</c>-returning call.
+    /// so that a chain of method calls does not have to be broken by a <see cref="void" />-returning call.
     /// </remarks>
     public readonly struct Unit : IEquatable<Unit>
     {
@@ -21,17 +21,19 @@ namespace Recore
         public static Unit Value { get; } = new Unit();
 
         /// <summary>
-        /// Converts a return type of <c>void</c> to a return type of <see cref="Unit" />.
+        /// Converts a return type of <see cref="void" /> to a return type of <see cref="Unit" />.
         /// </summary>
         public static Func<Unit> Close(Action action)
         {
             if (action == null)
+            {
                 throw new ArgumentNullException(nameof(action));
+            }
 
             return () =>
             {
                 action();
-                return Unit.Value;
+                return Value;
             };
         }
 

--- a/src/Recore/Uri.cs
+++ b/src/Recore/Uri.cs
@@ -8,24 +8,24 @@ namespace Recore
     public class AbsoluteUri : Uri
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="AbsoluteUri" /> with the given URI.
+        /// Initializes a new instance of <see cref="AbsoluteUri"/> with the given URI.
         /// </summary>
         public AbsoluteUri(string uriString) : base(uriString, UriKind.Absolute) { }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="AbsoluteUri" />
+        /// Initializes a new instance of <see cref="AbsoluteUri"/>
         /// with the given base URI and relative URI.
         /// </summary>
         public AbsoluteUri(Uri baseUri, string relativeUri) : base(baseUri, relativeUri) { }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="AbsoluteUri" />
+        /// Initializes a new instance of <see cref="AbsoluteUri"/>
         /// with the given base URI and relative URI.
         /// </summary>
         public AbsoluteUri(Uri baseUri, Uri relativeUri) : base(baseUri, relativeUri) { }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="AbsoluteUri" />
+        /// Initializes a new instance of <see cref="AbsoluteUri"/>
         /// with the given base URI and relative URI.
         /// </summary>
         public AbsoluteUri(Uri baseUri, RelativeUri relativeUri) : base(baseUri, relativeUri) { }
@@ -38,7 +38,7 @@ namespace Recore
         /// Appends a path to an absolute URI.
         /// </summary>
         /// <remarks>
-        /// This is a strongly typed alternative to the constructor <see cref="AbsoluteUri(Uri, string)" />.
+        /// This is a strongly typed alternative to the constructor <see cref="AbsoluteUri(Uri, string)"/>.
         /// Also, the constructor will keep the relative part of the base URI
         /// only if it is terminated with a slash.
         /// This operator ensures that the relative part of the base URI is always preserved.
@@ -49,7 +49,7 @@ namespace Recore
         /// Appends a path to an absolute URI.
         /// </summary>
         /// <remarks>
-        /// This is a strongly typed alternative to the constructor <see cref="AbsoluteUri(Uri, Uri)" />.
+        /// This is a strongly typed alternative to the constructor <see cref="AbsoluteUri(Uri, Uri)"/>.
         /// Also, the constructor will keep the relative part of the base URI
         /// only if it is terminated with a slash.
         /// This operator ensures that the relative part of the base URI is always preserved.
@@ -76,7 +76,7 @@ namespace Recore
     public class RelativeUri : Uri
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="RelativeUri" /> with the given URI.
+        /// Initializes a new instance of <see cref="RelativeUri"/> with the given URI.
         /// </summary>
         public RelativeUri(string uriString) : base(uriString, UriKind.Relative) { }
 
@@ -87,7 +87,7 @@ namespace Recore
         /// Appends a path to a relative URI.
         /// </summary>
         /// <remarks>
-        /// The constructor <see cref="Uri(Uri, string)" /> will throw a <see cref="UriFormatException" /> if called with two relative URIs.
+        /// The constructor <see cref="Uri(Uri, string)"/> will throw a <see cref="UriFormatException"/> if called with two relative URIs.
         /// </remarks>
         public RelativeUri Combine(string relativeUri) => Combine(new RelativeUri(relativeUri));
 
@@ -95,7 +95,7 @@ namespace Recore
         /// Appends a path to a relative URI.
         /// </summary>
         /// <remarks>
-        /// The constructor <see cref="Uri(Uri, Uri)" /> will throw a <see cref="UriFormatException" /> if called with two relative URIs.
+        /// The constructor <see cref="Uri(Uri, Uri)"/> will throw a <see cref="UriFormatException"/> if called with two relative URIs.
         /// </remarks>
         public RelativeUri Combine(RelativeUri relativeUri)
         {
@@ -115,19 +115,19 @@ namespace Recore
     }
 
     /// <summary>
-    /// Extension methods for the <see cref="Uri" /> type.
+    /// Extension methods for the <see cref="Uri"/> type.
     /// </summary>
     public static class UriExtensions
     {
         /// <summary>
-        /// Returns an instance of <see cref="AbsoluteUri" /> with the same value as <paramref name="uri" /> 
+        /// Returns an instance of <see cref="AbsoluteUri"/> with the same value as <paramref name="uri"/> 
         /// if it is absolute, or null if it is relative.
         /// </summary>
         /// <remarks>
-        /// Because an instance of <see cref="Uri" /> may be neither <see cref="AbsoluteUri" /> nor <see cref="RelativeUri" />,
+        /// Because an instance of <see cref="Uri"/> may be neither <see cref="AbsoluteUri"/> nor <see cref="RelativeUri"/>,
         /// patterns like <c>(AbsoluteUri)uri</c> or <c>uri as AbsoluteUri</c> cannot be used reliably.
-        /// <see cref="AsAbsoluteUri(Uri)" /> works as <c>uri as AbsoluteUri</c> would if <see cref="Uri" /> were an abstract base class.
-        /// It complements <see cref="Uri.IsAbsoluteUri" /> in this regard.
+        /// <see cref="AsAbsoluteUri(Uri)"/> works as <c>uri as AbsoluteUri</c> would if <see cref="Uri"/> were an abstract base class.
+        /// It complements <see cref="Uri.IsAbsoluteUri"/> in this regard.
         /// </remarks>
         public static AbsoluteUri AsAbsoluteUri(this Uri uri)
         {


### PR DESCRIPTION
I didn't know this at first when I started writing the doc comments.

Also, update all self-closing tags (like `<see>`) to not have a space before the `/>`.  This is how Visual Studio auto-completes it, so I'll just go with it.