### PR TITLE
Add notes on how finalizers interact with GC

### DIFF
--- a/docs/design-notes/Defer.md
+++ b/docs/design-notes/Defer.md
@@ -1,0 +1,12 @@
+# Defer
+
+## Why `sealed class`?
+Since the type is disposable, it is meant to be referenced through the `IDisposable` interface.
+If this were a value type, it would get boxed when referenced through the interface.
+
+## Why not define a finalizer to ensure the callback has been called?
+Throwing an exception from a finalizer will terminate the process,
+so it wouldn't be a good idea to invoke an arbitrary action in this case.
+
+Also, finalizers increase memory overhead, since the object will always survive the first GC attempt
+and go to the next generation.

--- a/test/Recore/DeferTests.cs
+++ b/test/Recore/DeferTests.cs
@@ -49,21 +49,17 @@ namespace Recore.Tests
         {
             bool called = false;
 
-            // Apparently, you need method scope for the GC to consider an object dead.
-            // A normal code block won't suffice.
-            void TestMethod()
+            // Allocate a Defer instance in a method scope
+            Func.Invoke(Unit.Close(() =>
             {
                 var defer = new Defer(() => called = true);
                 Assert.False(called);
-            }
+            }));
 
-            TestMethod();
-
-            // Even though GC.Collect() is supposed to block until GC is done,
-            // it seems that you have to wait on the finalizers as well.
+            // Garbage collection will put the finalizer in a queue,
+            // so we need to wait for the queue to empty.
             GC.Collect();
             GC.WaitForPendingFinalizers();
-            GC.Collect();
 
             Assert.False(called);
         }


### PR DESCRIPTION
I learned this recently, and it clears up some mystery in that unit test.
I'm also adding a design doc for `Defer` to record this decision.