### PR TITLE
Disable Azure Pipelines on PR builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -1,10 +1,4 @@
-pr:
-  branches:
-    include:
-    - master
-  paths:
-    exclude:
-    - docs/*
+pr: none
 
 trigger:
   branches:


### PR DESCRIPTION
GitHub Actions has proven to be sufficient on PR builds.  Also, it seems like Actions will just use the latest commit on the branch as the check while Azure Pipelines will go and trigger a new build.

That might be the behavior we want if we have multiple people working on the project and master moving more frequently.  But as long as it's just me, it seems like just a waste of time and resources waiting for the second build.