### PR TITLE
Upgrade to the new AZP UseDotNet@2 task

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -12,10 +12,11 @@ pool:
   vmImage: ubuntu-18.04
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: Install .NET Core SDK
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
   inputs:
     version: '2.2.401' # required by Coverlet
+    installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet build --configuration Release
   displayName: dotnet build


### PR DESCRIPTION
This has been producing a warning in the logs:

![image](https://user-images.githubusercontent.com/33549821/78516850-23055b80-7789-11ea-94f8-e95d1c404b39.png)

[Successful run](https://dev.azure.com/briancristante/RecoreFX/_build/results?buildId=310&view=results)