### PR TITLE
Add escapes to Glob and fix a bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_STORE
 
 .vs/
+.vscode/
 bin/
 obj/
 

--- a/src/Recore.Text/Glob.cs
+++ b/src/Recore.Text/Glob.cs
@@ -12,12 +12,12 @@ namespace Recore.Text
     public sealed class Glob
     {
         /// <summary>
-        /// Gets the pattern that was passed to the <c cref="Glob"/> constructor.
+        /// Gets the pattern that was passed to the <see cref="Glob"/> constructor.
         /// </summary>
         public string Pattern { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <c cref="Glob"/> type with the specified pattern.
+        /// Initializes a new instance of the <see cref="Glob"/> type with the specified pattern.
         /// </summary>
         public Glob(string pattern)
         {

--- a/src/Recore.Text/Glob.cs
+++ b/src/Recore.Text/Glob.cs
@@ -50,22 +50,21 @@ namespace Recore.Text
                     char patternChar = Pattern[patternIndex];
 
                     bool isEscape = false;
-                    // bool isEscape = false;
-                    // if (patternChar == '\\')
-                    // {
-                    //     // If the next pattern character is a wildcard, skip to it and escape it.
-                    //     // Otherwise, fall through to see if it matches the current text character.
-                    //     if (patternIndex + 1 < Pattern.Length)
-                    //     {
-                    //         char nextPatternChar = Pattern[patternIndex + 1];
-                    //         if (nextPatternChar == '*' || nextPatternChar == '?')
-                    //         {
-                    //             patternIndex++;
-                    //             patternChar = nextPatternChar;
-                    //             isEscape = true;
-                    //         }
-                    //     }
-                    // }
+                    if (patternChar == '\\')
+                    {
+                        // If the next pattern character is a wildcard, skip to it and escape it.
+                        // Otherwise, fall through to see if it matches the current text character.
+                        if (patternIndex + 1 < Pattern.Length)
+                        {
+                            char nextPatternChar = Pattern[patternIndex + 1];
+                            if (nextPatternChar == '*' || nextPatternChar == '?')
+                            {
+                                patternIndex++;
+                                patternChar = nextPatternChar;
+                                isEscape = true;
+                            }
+                        }
+                    }
 
                     if (patternChar == '*' && !isEscape)
                     {

--- a/src/Recore.Text/Glob.cs
+++ b/src/Recore.Text/Glob.cs
@@ -41,7 +41,7 @@ namespace Recore.Text
                     // TODO false positives with escapes:
                     // don't split an escape character
                     var subpattern = new Glob(Pattern.Substring(patternIndex));
-                    return Enumerable.Range(textIndex, text.Length - 1)
+                    return Enumerable.Range(textIndex, count: text.Length - textIndex)
                         .Select(x => text.Substring(x))
                         .Any(subpattern.IsMatch);
                 }

--- a/src/Recore.Text/Glob.cs
+++ b/src/Recore.Text/Glob.cs
@@ -12,12 +12,12 @@ namespace Recore.Text
     public sealed class Glob
     {
         /// <summary>
-        /// Gets the pattern that was passed to the <c cref="Glob">Glob</c> constructor.
+        /// Gets the pattern that was passed to the <c cref="Glob"/> constructor.
         /// </summary>
         public string Pattern { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <c cref="Glob">Glob</c> type with the specified pattern.
+        /// Initializes a new instance of the <c cref="Glob"/> type with the specified pattern.
         /// </summary>
         public Glob(string pattern)
         {

--- a/src/Recore.Text/Glob.cs
+++ b/src/Recore.Text/Glob.cs
@@ -37,9 +37,7 @@ namespace Recore.Text
             {
                 if (expandingStar)
                 {
-                    // Skip ahead to all possible positions and start matching again.
-                    // TODO false positives with escapes:
-                    // don't split an escape character
+                    // Skip ahead to all possible positions in `text` and start matching again.
                     var subpattern = new Glob(Pattern.Substring(patternIndex));
                     return Enumerable.Range(textIndex, count: text.Length - textIndex)
                         .Select(x => text.Substring(x))

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -24,6 +24,7 @@ namespace Recore.Text.Tests
         {
             Assert.True(new Glob("*").IsMatch(""));
             Assert.True(new Glob("*").IsMatch("abc"));
+            Assert.True(new Glob("*").IsMatch("hello world"));
         }
 
         [Fact]
@@ -57,6 +58,7 @@ namespace Recore.Text.Tests
             Assert.True(new Glob("a*b").IsMatch("ab"));
             Assert.True(new Glob("a*b").IsMatch("abbbb"));
             Assert.False(new Glob("a*b").IsMatch("abbbbc"));
+            Assert.True(new Glob("*ll*").IsMatch("hello world"));
         }
 
         [Fact]
@@ -94,13 +96,27 @@ namespace Recore.Text.Tests
             Assert.True(new Glob("\\?").IsMatch("?"));
             Assert.False(new Glob("\\*").IsMatch(""));
             Assert.False(new Glob("\\*").IsMatch("a"));
+            Assert.False(new Glob("\\*").IsMatch("\\*"));
             Assert.False(new Glob("\\?").IsMatch("a"));
+            Assert.False(new Glob("\\?").IsMatch("\\?"));
 
             Assert.True(new Glob("a\\*").IsMatch("a*"));
             Assert.True(new Glob("a\\?").IsMatch("ab"));
             Assert.False(new Glob("a\\*").IsMatch("a"));
             Assert.False(new Glob("a\\*").IsMatch("ab"));
             Assert.False(new Glob("a\\?").IsMatch("ab"));
+
+            Assert.True(new Glob("*\\*").IsMatch("*"));
+            Assert.True(new Glob("a*\\*a").IsMatch("a*a"));
+            Assert.True(new Glob("a*\\*a").IsMatch("abc*a"));
+        }
+
+        [Fact]
+        public void NonescapingBackslash()
+        {
+            Assert.True(new Glob("\\").IsMatch("\\"));
+            Assert.True(new Glob("\\a").IsMatch("\\a"));
+            Assert.True(new Glob("*\\a?").IsMatch("hello world\\ab"));
         }
     }
 }

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -22,7 +22,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void JustAsterisk()
+        public void JustStar()
         {
             Assert.True(new Glob("*").IsMatch(""));
             Assert.True(new Glob("*").IsMatch("abc"));
@@ -30,7 +30,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void AsteriskAtBeginning()
+        public void StarAtBeginning()
         {
             Assert.True(new Glob("*a").IsMatch("a"));
             Assert.True(new Glob("*a").IsMatch("bba"));
@@ -38,7 +38,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void AsteriskInMiddle()
+        public void StarInMiddle()
         {
             Assert.False(new Glob("a*b").IsMatch("a"));
             Assert.False(new Glob("a*b").IsMatch("aa"));
@@ -49,7 +49,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void AsteriskAtEnd()
+        public void StarAtEnd()
         {
             Assert.True(new Glob("a*").IsMatch("abc"));
             Assert.True(new Glob("a*").IsMatch("a*"));
@@ -57,7 +57,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void MultipleAsterisks()
+        public void MultipleStars()
         {
             Assert.True(new Glob("*ab*").IsMatch("ab"));
             Assert.True(new Glob("*ab*").IsMatch("123ab456"));

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -121,6 +121,7 @@ namespace Recore.Text.Tests
             Assert.True(new Glob("*\\*").IsMatch("*"));
             Assert.True(new Glob("a*\\*a").IsMatch("a*a"));
             Assert.True(new Glob("a*\\*a").IsMatch("abc*a"));
+            Assert.False(new Glob("*\\*a").IsMatch("aaa"));
         }
 
         [Fact]

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -28,26 +28,11 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void JustQuestionMark()
+        public void AsteriskAtBeginning()
         {
-            Assert.False(new Glob("?").IsMatch(""));
-            Assert.True(new Glob("?").IsMatch("x"));
-        }
-
-        [Fact]
-        public void SingleWildcard()
-        {
-            Assert.True(new Glob("a?c").IsMatch("abc"));
-            Assert.True(new Glob("a?c").IsMatch("axc"));
-            Assert.True(new Glob("a?c").IsMatch("a?c"));
-        }
-
-        [Fact]
-        public void AsteriskAtEnd()
-        {
-            Assert.True(new Glob("a*").IsMatch("abc"));
-            Assert.True(new Glob("a*").IsMatch("a*"));
-            Assert.False(new Glob("a*").IsMatch("bc"));
+            Assert.True(new Glob("*a").IsMatch("a"));
+            Assert.True(new Glob("*a").IsMatch("bba"));
+            Assert.False(new Glob("*a").IsMatch("abc"));
         }
 
         [Fact]
@@ -62,6 +47,14 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
+        public void AsteriskAtEnd()
+        {
+            Assert.True(new Glob("a*").IsMatch("abc"));
+            Assert.True(new Glob("a*").IsMatch("a*"));
+            Assert.False(new Glob("a*").IsMatch("bc"));
+        }
+
+        [Fact]
         public void MultipleAsterisks()
         {
             Assert.True(new Glob("*ab*").IsMatch("ab"));
@@ -71,6 +64,21 @@ namespace Recore.Text.Tests
             Assert.True(new Glob("*/*/*").IsMatch("foo/bar/baz/bash"));
             Assert.True(new Glob("*/*/*").IsMatch("foo/bar/"));
             Assert.False(new Glob("*/*/*").IsMatch("foo/bar"));
+        }
+
+        [Fact]
+        public void JustQuestionMark()
+        {
+            Assert.False(new Glob("?").IsMatch(""));
+            Assert.True(new Glob("?").IsMatch("x"));
+        }
+
+        [Fact]
+        public void QuestionMarkInMiddle()
+        {
+            Assert.True(new Glob("a?c").IsMatch("abc"));
+            Assert.True(new Glob("a?c").IsMatch("axc"));
+            Assert.True(new Glob("a?c").IsMatch("a?c"));
         }
 
         [Fact]
@@ -92,8 +100,10 @@ namespace Recore.Text.Tests
         [Fact]
         public void EscapedWildcardCharacters()
         {
+            Assert.True(new Glob("\\").IsMatch("\\"));
             Assert.True(new Glob("\\*").IsMatch("*"));
             Assert.True(new Glob("\\?").IsMatch("?"));
+            Assert.True(new Glob("\\\\*").IsMatch("\\*"));
             Assert.False(new Glob("\\*").IsMatch(""));
             Assert.False(new Glob("\\*").IsMatch("a"));
             Assert.False(new Glob("\\*").IsMatch("\\*"));
@@ -101,7 +111,7 @@ namespace Recore.Text.Tests
             Assert.False(new Glob("\\?").IsMatch("\\?"));
 
             Assert.True(new Glob("a\\*").IsMatch("a*"));
-            Assert.True(new Glob("a\\?").IsMatch("ab"));
+            Assert.True(new Glob("a\\?").IsMatch("a?"));
             Assert.False(new Glob("a\\*").IsMatch("a"));
             Assert.False(new Glob("a\\*").IsMatch("ab"));
             Assert.False(new Glob("a\\?").IsMatch("ab"));

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace Recore.Text.Tests
 {
-    public class WildcardTests
+    public class GlobTests
     {
         [Fact]
         public void EmptyPattern()

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -14,7 +14,9 @@ namespace Recore.Text.Tests
         [Fact]
         public void NoWildcardCharacters()
         {
+            Assert.True(new Glob("a").IsMatch("a"));
             Assert.True(new Glob("abc").IsMatch("abc"));
+            Assert.False(new Glob("a").IsMatch(""));
             Assert.False(new Glob("abc").IsMatch("ab"));
             Assert.False(new Glob("abc").IsMatch("abcd"));
         }

--- a/test/Recore.Text/GlobTests.cs
+++ b/test/Recore.Text/GlobTests.cs
@@ -12,7 +12,7 @@ namespace Recore.Text.Tests
         }
 
         [Fact]
-        public void NoSpecialCharacters()
+        public void NoWildcardCharacters()
         {
             Assert.True(new Glob("abc").IsMatch("abc"));
             Assert.False(new Glob("abc").IsMatch("ab"));
@@ -36,13 +36,16 @@ namespace Recore.Text.Tests
         [Fact]
         public void SingleWildcard()
         {
+            Assert.True(new Glob("a?c").IsMatch("abc"));
             Assert.True(new Glob("a?c").IsMatch("axc"));
+            Assert.True(new Glob("a?c").IsMatch("a?c"));
         }
 
         [Fact]
         public void AsteriskAtEnd()
         {
             Assert.True(new Glob("a*").IsMatch("abc"));
+            Assert.True(new Glob("a*").IsMatch("a*"));
             Assert.False(new Glob("a*").IsMatch("bc"));
         }
 
@@ -82,6 +85,22 @@ namespace Recore.Text.Tests
             Assert.True(new Glob("?*/?*/?*").IsMatch("foo/bar/baz/bash"));
             Assert.False(new Glob("?*/?*/?*").IsMatch("foo/bar/"));
             Assert.False(new Glob("?*/?*/?*").IsMatch("foo/bar"));
+        }
+
+        [Fact]
+        public void EscapedWildcardCharacters()
+        {
+            Assert.True(new Glob("\\*").IsMatch("*"));
+            Assert.True(new Glob("\\?").IsMatch("?"));
+            Assert.False(new Glob("\\*").IsMatch(""));
+            Assert.False(new Glob("\\*").IsMatch("a"));
+            Assert.False(new Glob("\\?").IsMatch("a"));
+
+            Assert.True(new Glob("a\\*").IsMatch("a*"));
+            Assert.True(new Glob("a\\?").IsMatch("ab"));
+            Assert.False(new Glob("a\\*").IsMatch("a"));
+            Assert.False(new Glob("a\\*").IsMatch("ab"));
+            Assert.False(new Glob("a\\?").IsMatch("ab"));
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/recorefx/RecoreFX/issues/67

Also fixes a bug where matching with `*` did not work in all cases because a wrong argument was being passed to `Enumerable.Range`.