### PR TITLE
Convert Token to a subtype of Of

### DIFF
--- a/docs/design-notes/Token.md
+++ b/docs/design-notes/Token.md
@@ -1,0 +1,7 @@
+# Token
+
+I used to have this as its own type, but I refactored it to be a subtype of `Of<string>` since it's really using that pattern and a lot of code could be eliminated.
+
+I also used to have overloads for its methods taking `string` and an implicit conversion operator to `string` so `Token` would feel more like a subtype of `string`.
+I decided I didn't want to add all that to `Of<T>`, so I deleted it here.
+Though, it wouldn't be a breaking change to add that later if it's desirable.

--- a/src/Recore/Of.cs
+++ b/src/Recore/Of.cs
@@ -8,7 +8,8 @@ namespace Recore
     /// <remarks>
     /// Use <see cref="Of{T}"/> to create a strongly-typed "alias" of another type.
     ///
-    /// You can use a <c>using</c> directive to create an alias for a type, but the scope of that alias is limited to that file.
+    /// You can use a <c>using</c> directive to create an alias for a type,
+    /// but the scope of that alias is limited to that file.
     /// Furthermore, the alias is just that -- an alias -- not a separate type.
     /// So, an alias won't prevent errors like this:
     /// <code>
@@ -52,6 +53,10 @@ namespace Recore
         /// <summary>
         /// Determines whether two instances of the type are equal.
         /// </summary>
+        /// <remarks>
+        /// Note that instances of two separate subtypes of <see cref="Of{T}"/>
+        /// will compare equal to each other if their values are the same type and are equal.
+        /// </remarks>
         public bool Equals(Of<T> other)
             => other != null
             && Equals(Value, other.Value);

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -7,6 +7,11 @@ namespace Recore
     /// <summary>
     /// Represents a non-null, non-empty string value where whitespace is not allowed.
     /// </summary>
+    /// <remarks>
+    /// This type implements <see cref="IComparable{T}"/> with <c cref="Of{T}">Of&lt;String&gt;</c>
+    /// instead of <c cref="Of{T}">Of&lt;Token&gt;</c>.
+    /// This is for parity with its inherited implementation of <c cref="IEquatable{T}">IEquatable&lt;Of&lt;String&gt;&gt;</c>.
+    /// </remarks>
     public sealed class Token : Of<string>, IComparable<Of<string>>
     {
         /// <summary>

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -7,13 +7,15 @@ namespace Recore
     /// <summary>
     /// Represents a non-null, non-empty string value where whitespace is not allowed.
     /// </summary>
-    /// <remarks>
-    /// This type is meant to feel like a subclass of <see cref="string"/>, which is sealed.
-    /// </remarks>
-    public sealed class Token : IEquatable<Token>, IComparable<Token>, IEquatable<string>, IComparable<string>
+    public sealed class Token : IEquatable<Token>, IComparable<Token>
     {
-        // Guaranteed to be non-null, nonzero length, and no whitespace
-        private readonly string value;
+        /// <summary>
+        /// The value of the token.
+        /// </summary>
+        /// <remarks>
+        /// This is guaranteed to be non-null, have nonzero length, and have no whitespace.
+        /// </remarks>
+        public string Value { get; }
 
         /// <summary>
         /// Constructs an instance of <see cref="Token"/> from a string value.
@@ -38,13 +40,13 @@ namespace Recore
                 }
             }
 
-            this.value = value;
+            Value = value;
         }
 
         /// <summary>
         /// Returns the underlying string value.
         /// </summary>
-        public override string ToString() => value;
+        public override string ToString() => Value;
 
         /// <summary>
         /// Determines whether this instance and another object,
@@ -57,10 +59,6 @@ namespace Recore
             {
                 return this.Equals(token);
             }
-            else if (obj is string str)
-            {
-                return this.Equals(str);
-            }
             else
             {
                 return false;
@@ -71,13 +69,7 @@ namespace Recore
         /// Determines whether this instance and another <see cref="Token"/>
         /// have the same value.
         /// </summary>
-        public bool Equals(Token other) => value == other.value;
-
-        /// <summary>
-        /// Determines whether this instance and a <see cref="string"/>
-        /// have the same value.
-        /// </summary>
-        public bool Equals(string other) => value.Equals(other);
+        public bool Equals(Token other) => Value == other.Value;
 
         /// <summary>
         /// Determines whether two instances of <see cref="Token"/>
@@ -94,29 +86,17 @@ namespace Recore
         /// <summary>
         /// Returns the hash code of the underlying value.
         /// </summary>
-        public override int GetHashCode() => value.GetHashCode();
+        public override int GetHashCode() => Value.GetHashCode();
 
         /// <summary>
         /// Compares this instance with a specified <see cref="Token"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
-        public int CompareTo(Token other) => value.CompareTo(other.value);
+        public int CompareTo(Token other) => Value.CompareTo(other.Value);
 
-        /// <summary>
-        /// Compares this instance with a specified <see cref="string"/> object
-        /// and indicates whether this instance precedes, follows, or appears in the same position
-        /// in the sort order as the specified object.
-        /// </summary>
-        public int CompareTo(string other) => value.CompareTo(other);
-
-        /// <summary>
-        /// Converts this instance to its underlying value.
-        /// </summary>
-        public static implicit operator string(Token t) => t.ToString();
-
-        // Implicit conversion to string gives us the string == and != operators for free
-        // For some reason, String implements IComparable but does not have comparison operators
+        // For some reason, String implements IComparable but does not have comparison operators.
+        // Therefore, I won't add them to Token, either.
     }
 
     /// <summary>

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -66,10 +66,29 @@ namespace Recore
         }
 
         /// <summary>
+        /// Returns the hash code of the underlying value.
+        /// </summary>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <summary>
+        /// Compares this instance with a specified <see cref="Token"/> object
+        /// and indicates whether this instance precedes, follows, or appears in the same position
+        /// in the sort order as the specified object.
+        /// </summary>
+        public int CompareTo(Token other) => Value.CompareTo(other.Value);
+
+        /// <summary>
         /// Determines whether this instance and another <see cref="Token"/>
         /// have the same value.
         /// </summary>
-        public bool Equals(Token other) => Value == other.Value;
+        public bool Equals(Token other) => Value.Equals(other.Value);
+
+        /// <summary>
+        /// Determines whether this instance and another <see cref="Token"/>
+        /// have the same value.
+        /// A parameter specifies the culture, case, and sort rules used in the comparison.
+        /// </summary>
+        public bool Equals(Token other, StringComparison comparisonType) => Value.Equals(other.Value, comparisonType);
 
         /// <summary>
         /// Determines whether two instances of <see cref="Token"/>
@@ -82,18 +101,6 @@ namespace Recore
         /// have different values.
         /// </summary>
         public static bool operator !=(Token lhs, Token rhs) => !Equals(lhs, rhs);
-
-        /// <summary>
-        /// Returns the hash code of the underlying value.
-        /// </summary>
-        public override int GetHashCode() => Value.GetHashCode();
-
-        /// <summary>
-        /// Compares this instance with a specified <see cref="Token"/> object
-        /// and indicates whether this instance precedes, follows, or appears in the same position
-        /// in the sort order as the specified object.
-        /// </summary>
-        public int CompareTo(Token other) => Value.CompareTo(other.Value);
 
         // For some reason, String implements IComparable but does not have comparison operators.
         // Therefore, I won't add them to Token, either.

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -7,16 +7,8 @@ namespace Recore
     /// <summary>
     /// Represents a non-null, non-empty string value where whitespace is not allowed.
     /// </summary>
-    public sealed class Token : IEquatable<Token>, IComparable<Token>
+    public sealed class Token : Of<string>, IComparable<Of<string>>
     {
-        /// <summary>
-        /// The value of the token.
-        /// </summary>
-        /// <remarks>
-        /// This is guaranteed to be non-null, have nonzero length, and have no whitespace.
-        /// </remarks>
-        public string Value { get; }
-
         /// <summary>
         /// Constructs an instance of <see cref="Token"/> from a string value.
         /// </summary>
@@ -44,63 +36,18 @@ namespace Recore
         }
 
         /// <summary>
-        /// Returns the underlying string value.
-        /// </summary>
-        public override string ToString() => Value;
-
-        /// <summary>
-        /// Determines whether this instance and another object,
-        /// which must be a <see cref="Token"/> or a <see cref="string"/>,
+        /// Determines whether this instance and another <see cref="Token"/>
         /// have the same value.
+        /// A parameter specifies the culture, case, and sort rules used in the comparison.
         /// </summary>
-        public override bool Equals(object obj)
-        {
-            if (obj is Token token)
-            {
-                return this.Equals(token);
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Returns the hash code of the underlying value.
-        /// </summary>
-        public override int GetHashCode() => Value.GetHashCode();
+        public bool Equals(Of<string> other, StringComparison comparisonType) => Value.Equals(other.Value, comparisonType);
 
         /// <summary>
         /// Compares this instance with a specified <see cref="Token"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
-        public int CompareTo(Token other) => Value.CompareTo(other.Value);
-
-        /// <summary>
-        /// Determines whether this instance and another <see cref="Token"/>
-        /// have the same value.
-        /// </summary>
-        public bool Equals(Token other) => Value.Equals(other.Value);
-
-        /// <summary>
-        /// Determines whether this instance and another <see cref="Token"/>
-        /// have the same value.
-        /// A parameter specifies the culture, case, and sort rules used in the comparison.
-        /// </summary>
-        public bool Equals(Token other, StringComparison comparisonType) => Value.Equals(other.Value, comparisonType);
-
-        /// <summary>
-        /// Determines whether two instances of <see cref="Token"/>
-        /// have the same value.
-        /// </summary>
-        public static bool operator ==(Token lhs, Token rhs) => Equals(lhs, rhs);
-
-        /// <summary>
-        /// Determines whether two instances of <see cref="Token"/>
-        /// have different values.
-        /// </summary>
-        public static bool operator !=(Token lhs, Token rhs) => !Equals(lhs, rhs);
+        public int CompareTo(Of<string> other) => Value.CompareTo(other.Value);
 
         // For some reason, String implements IComparable but does not have comparison operators.
         // Therefore, I won't add them to Token, either.

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -31,7 +31,14 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void ConvertToString()
+        public void Value()
+        {
+            Assert.Equal("hello", new Token("hello").Value);
+            Assert.NotEqual("asdf", new Token("hello").Value);
+        }
+
+        [Fact]
+        public void ToString_()
         {
             Assert.Equal("hello", new Token("hello").ToString());
             Assert.NotEqual("asdf", new Token("hello").ToString());
@@ -67,43 +74,19 @@ namespace Recore.Tests
             var helloworld2 = new Token("hello" + "world");
             Assert.True(helloworld1.Equals((object)helloworld2));
 
-            Assert.True(helloworld1.Equals("helloworld"));
-            Assert.Equal("helloworld", helloworld1);
+            Assert.False(helloworld1.Equals("helloworld"));
             Assert.False(helloworld1.Equals(new Exception()));
 
             Assert.True(Equals(helloworld1, helloworld2));
-            Assert.True(Equals(helloworld1, "helloworld"));
-
-            // string.Equals
-            Assert.True(string.Equals("hello", new Token("HELLO"), StringComparison.InvariantCultureIgnoreCase));
+            Assert.False(Equals(helloworld1, "helloworld"));
 
             // operator==
             Assert.True(helloworld1 == helloworld2);
             Assert.True(helloworld2 == helloworld1);
 
-            Assert.True(helloworld1 == "helloworld");
-            Assert.True("helloworld" == helloworld1);
-
             var asdf = new Token("asdf");
             Assert.False(helloworld1 == asdf);
             Assert.True(helloworld1 != asdf);
-        }
-
-        [Fact]
-        public void ImplicitConversionToString()
-        {
-            var world = new Token("world");
-            var message = "hello " + world;
-            Assert.Equal("hello world", message);
-
-            var dictionary = new Dictionary<string, int>
-            {
-                ["burrito"] = 1,
-                ["enchilada"] = 2,
-                ["chalupa"] = 3
-            };
-
-            Assert.Equal(1, dictionary[new Token("burrito")]);
         }
 
         [Fact]
@@ -126,10 +109,6 @@ namespace Recore.Tests
             Assert.Equal(-1, new Token("abc").CompareTo(new Token("def")));
             Assert.Equal(0, new Token("abc").CompareTo(new Token("abc")));
             Assert.Equal(1, new Token("def").CompareTo(new Token("abc")));
-
-            Assert.Equal(-1, "abc".CompareTo(new Token("def")));
-            Assert.Equal(0, "abc".CompareTo(new Token("abc")));
-            Assert.Equal(1, "def".CompareTo(new Token("abc")));
         }
 
         [Fact]

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -81,7 +81,7 @@ namespace Recore.Tests
             Assert.False(Equals(helloworld1, "helloworld"));
         }
 
-        [Fact]
+        [Fact(Skip="https://github.com/recorefx/RecoreFX/issues/94")]
         public void EqualsWithStringComparison()
         {
             var aether = new Token("aether");
@@ -89,7 +89,7 @@ namespace Recore.Tests
 
             Assert.False(aether.Equals(æther));
             Assert.False(aether.Equals(æther, StringComparison.Ordinal));
-            Assert.True(aether.Equals(æther, StringComparison.CurrentCulture));
+            Assert.True(aether.Equals(æther, StringComparison.InvariantCulture));
         }
 
         [Fact]

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -79,14 +79,17 @@ namespace Recore.Tests
 
             Assert.True(Equals(helloworld1, helloworld2));
             Assert.False(Equals(helloworld1, "helloworld"));
+        }
 
-            // operator==
-            Assert.True(helloworld1 == helloworld2);
-            Assert.True(helloworld2 == helloworld1);
+        [Fact]
+        public void EqualsWithStringComparison()
+        {
+            var aether = new Token("aether");
+            var æther = new Token("æther");
 
-            var asdf = new Token("asdf");
-            Assert.False(helloworld1 == asdf);
-            Assert.True(helloworld1 != asdf);
+            Assert.False(aether.Equals(æther));
+            Assert.False(aether.Equals(æther, StringComparison.Ordinal));
+            Assert.True(aether.Equals(æther, StringComparison.CurrentCulture));
         }
 
         [Fact]

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -85,11 +85,11 @@ namespace Recore.Tests
         public void EqualsWithStringComparison()
         {
             var aether = new Token("aether");
-            var æther = new Token("æther");
+            var Ã¦ther = new Token("Ã¦ther");
 
-            Assert.False(aether.Equals(æther));
-            Assert.False(aether.Equals(æther, StringComparison.Ordinal));
-            Assert.True(aether.Equals(æther, StringComparison.CurrentCulture));
+            Assert.False(aether.Equals(Ã¦ther));
+            Assert.False(aether.Equals(Ã¦ther, StringComparison.Ordinal));
+            Assert.True(aether.Equals(Ã¦ther, StringComparison.CurrentCulture));
         }
 
         [Fact]


### PR DESCRIPTION
I made `Token` before I made `Of`.  This consolidates concepts and simplifies the API.

I'm removing the string overloads and conversion operator from `Token` for now.  See the design notes .