### PR TITLE
Add back anonymous comparers

### DIFF
--- a/src/Recore.Collections.Generic/AnonymousComparer.cs
+++ b/src/Recore.Collections.Generic/AnonymousComparer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Recore.Collections.Generic
+{
+    /// <summary>
+    /// Compares instances of a type using the given comparison function.
+    /// </summary>
+    public sealed class AnonymousComparer<T> : IComparer<T>
+    {
+        private readonly Func<T, T, int> compare;
+
+        /// <summary>
+        /// Creates an instance of <see cref="AnonymousComparer{T}"/>.
+        /// </summary>
+        public AnonymousComparer(Func<T, T, int> compare)
+        {
+            this.compare = compare ?? throw new ArgumentNullException(nameof(compare));
+        }
+
+        /// <summary>
+        /// Invokes the given comparison function on two objects.
+        /// </summary>
+        public int Compare(T x, T y) => compare(x, y);
+    }
+}

--- a/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
@@ -20,7 +20,6 @@ namespace Recore.Collections.Generic
             this.getHashCode = getHashCode ?? throw new ArgumentNullException(nameof(getHashCode));
         }
 
-
         /// <summary>
         /// Invokes the given comparison function on two objects.
         /// </summary>

--- a/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Recore.Collections.Generic
+{
+    /// <summary>
+    /// Compares instances of a type using the given equality function.
+    /// </summary>
+    public sealed class AnonymousEqualityComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T, T, bool> equals;
+        private readonly Func<T, int> getHashCode;
+
+        /// <summary>
+        /// Creates an instance of <see cref="AnonymousEqualityComparer{T}"/>.
+        /// </summary>
+        public AnonymousEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode)
+        {
+            this.equals = equals ?? throw new ArgumentNullException(nameof(equals));
+            this.getHashCode = getHashCode ?? throw new ArgumentNullException(nameof(getHashCode));
+        }
+
+
+        /// <summary>
+        /// Invokes the given comparison function on two objects.
+        /// </summary>
+        public bool Equals(T x, T y) => equals(x, y);
+
+
+        /// <summary>
+        /// Invokes the given hashing function on an object.
+        /// </summary>
+        public int GetHashCode(T obj) => getHashCode(obj);
+    }
+}


### PR DESCRIPTION
I thought at first the `Mapping` comparers were good enough, but I realized that these have use cases too.  For example, if you only want to compare on a subset of a type's properties, you could use these.