### PR TITLE
Usability tune-up for Optional's conditional methods

### DIFF
--- a/docs/design-notes/Optional.md
+++ b/docs/design-notes/Optional.md
@@ -47,6 +47,19 @@ Without this constraint, you have to maintain additional state to know whether t
     - Again, `Bind` isn't evocative for users unfamiliar with functional programming.
     - `Then` evokes a monad bind that many people are familiar with, that of Promises in JavaScript. .NET's own `ContinueWith` is a little too clumsy and more specific to asynchronous programming.
 
+## Why no `OnEmpty()` or `IfEmpty`?
+
+These don't really add any value. You can just do:
+
+```cs
+if (!optional.HasValue)
+{
+    // ...
+}
+```
+
+For `OnValue()` and `IfValue()`, you need a way to get to the underlying value.
+
 # Why not make Optional<T> implement IEnumerable<T>?
 - I saw someone explain optional types once as a list that can have either 0 or 1 element. I thought that was an interesting explanation.
 - It was straightforward to implement and I thought it was cool to unify the two concepts, so I went for it in a prelease version of `Optional<T>`.

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -125,14 +125,6 @@ namespace Recore
                 () => { });
 
         /// <summary>
-        /// Takes an action only if the <see cref="Optional{T}"/> is empty.
-        /// </summary>
-        public void IfEmpty(Action onEmpty)
-            => Switch(
-                x => { },
-                onEmpty);
-
-        /// <summary>
         /// Chains another <see cref="Optional{T}"/>-producing operation onto the result of another.
         /// </summary>
         /// <remarks>

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -248,6 +248,29 @@ namespace Recore
         }
 
         /// <summary>
+        /// Sets an optional value if a condition is true.
+        /// </summary>
+        /// <remarks>
+        /// This method is useful for converting the <c>TryParse</c> pattern to an <see cref="Optional{T}"/> result.
+        /// </remarks>
+        public static Optional<T> If<T>(bool condition, Func<T> func)
+        {
+            if (func is null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            if (condition)
+            {
+                return Of(func());
+            }
+            else
+            {
+                return Optional<T>.Empty;
+            }
+        }
+
+        /// <summary>
         /// Converts a unary action to work with <see cref="Optional{T}"/>.
         /// </summary>
         public static Action<Optional<T>> Lift<T>(Action<T> action)

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -383,6 +383,31 @@ namespace Recore.Tests
 
             var failure = Optional.If(int.TryParse("abc", out result), result);
             Assert.False(failure.HasValue);
+
+            Optional<int> optional;
+            bool called;
+
+            called = false;
+            optional = Optional.If(true, () =>
+            {
+                called = true;
+                return 123;
+            });
+
+            Assert.True(called);
+            Assert.Equal(123, optional);
+
+            called = false;
+            optional = Optional.If(false, () =>
+            {
+                called = true;
+                return 123;
+            });
+
+            Assert.False(called);
+            Assert.False(optional.HasValue);
+
+            Assert.Throws<ArgumentNullException>(() => Optional.If<int>(true, null));
         }
 
         [Fact]

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -130,7 +130,7 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void IfValueIfEmpty()
+        public void IfValue()
         {
             Optional<int> optional;
             bool called;
@@ -140,18 +140,10 @@ namespace Recore.Tests
             optional.IfValue(x => { called = true; });
             Assert.True(called);
 
-            called = false;
-            optional.IfEmpty(() => { called = true; });
-            Assert.False(called);
-
             optional = Optional<int>.Empty;
             called = false;
             optional.IfValue(x => { called = true; });
             Assert.False(called);
-
-            called = false;
-            optional.IfEmpty(() => { called = true; });
-            Assert.True(called);
         }
 
         [Fact]


### PR DESCRIPTION
- Remove `Optional<T>.IfEmpty()`.  Just use `if !(optional.HasValue)` instead.
- Add lazily-evaluated `Optional.If` overload.