### PR TITLE
Add tests for Optional.Lift and Renumerable

### DIFF
--- a/src/Recore.Linq/KeyValuePair.cs
+++ b/src/Recore.Linq/KeyValuePair.cs
@@ -19,11 +19,11 @@ namespace Recore.Linq
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TKey, TResult> func)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
-            if (func == null)
+            if (func is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -41,11 +41,11 @@ namespace Recore.Linq
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TValue, TResult> func)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
-            if (func == null)
+            if (func is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }

--- a/src/Recore.Linq/KeyValuePair.cs
+++ b/src/Recore.Linq/KeyValuePair.cs
@@ -18,10 +18,21 @@ namespace Recore.Linq
         public static IEnumerable<KeyValuePair<TResult, TValue>> OnKeys<TKey, TValue, TResult>(
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TKey, TResult> func)
-            => source
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source
                 // TODO .NET Standard 2.1 use KeyValuePair.Create
                 .Select(kvp => new KeyValuePair<TResult, TValue>(func(kvp.Key), kvp.Value))
                 .ToDictionary();
+        }
 
         /// <summary>
         /// Projects each value in a sequence of key-value pairs to a new form.
@@ -29,9 +40,20 @@ namespace Recore.Linq
         public static IEnumerable<KeyValuePair<TKey, TResult>> OnValues<TKey, TValue, TResult>(
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TValue, TResult> func)
-            => source
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source
                 // TODO .NET Standard 2.1 use KeyValuePair.Create
                 .Select(kvp => new KeyValuePair<TKey, TResult>(kvp.Key, func(kvp.Value)))
                 .ToDictionary();
+        }
     }
 }

--- a/test/Recore.Linq/ForEachTests.cs
+++ b/test/Recore.Linq/ForEachTests.cs
@@ -29,7 +29,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ForEachWithValues()
         {
-            // Type as IEnumeable to avoid calling List<T>.ForEach()
+            // Type as IEnumerable to avoid calling List<T>.ForEach()
             IEnumerable<int> enumerable = new List<int> { 1, 2, 3, 4, 5 };
 
             int timesCalled = 0;

--- a/test/Recore.Linq/ForEachTests.cs
+++ b/test/Recore.Linq/ForEachTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Xunit;
+
+namespace Recore.Linq.Tests
+{
+    public class ForEachTests
+    {
+        [Fact]
+        public void ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.ForEach<object>(null, x => { }));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Enumerable.Empty<object>().ForEach(null));
+        }
+
+        [Fact]
+        public void ForEachEmpty()
+        {
+            int timesCalled = 0;
+            Enumerable.Empty<object>().ForEach(x => { ++timesCalled; });
+            Assert.Equal(0, timesCalled);
+        }
+
+        [Fact]
+        public void ForEachWithValues()
+        {
+            // Type as IEnumeable to avoid calling List<T>.ForEach()
+            IEnumerable<int> enumerable = new List<int> { 1, 2, 3, 4, 5 };
+
+            int timesCalled = 0;
+            enumerable.ForEach(x => { ++timesCalled; });
+
+            Assert.Equal(5, timesCalled);
+        }
+    }
+}

--- a/test/Recore.Linq/KeyValuePairTests.cs
+++ b/test/Recore.Linq/KeyValuePairTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Xunit;
+
+namespace Recore.Linq.Tests
+{
+    public class KeyValuePairTests
+    {
+        [Fact]
+        public void ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.ToDictionary<string, int>(null));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.OnKeys<string, int, int>(null, x => 1));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Enumerable.Empty<KeyValuePair<string, int>>().OnKeys<string, int, int>(null));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.OnValues<string, int, int>(null, x => 1));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Enumerable.Empty<KeyValuePair<string, int>>().OnValues<string, int, int>(null));
+        }
+
+        [Fact]
+        public void ToDictionary()
+        {
+            var enumerable = new List<KeyValuePair<string, int>>
+            {
+                KeyValuePair.Create("burrito", 8),
+                KeyValuePair.Create("taco", 6),
+                KeyValuePair.Create("margarita", 7),
+            };
+
+            var dictionary = new Dictionary<string, int>
+            {
+                ["burrito"] = 8,
+                ["taco"] = 6,
+                ["margarita"] = 7
+            };
+
+            Assert.Equal(dictionary, enumerable.ToDictionary());
+        }
+
+        [Fact]
+        public void OnKeys()
+        {
+            var dictionary = new Dictionary<string, int>
+            {
+                ["burrito"] = 8,
+                ["taco"] = 6,
+                ["margarita"] = 7,
+            };
+
+            var actual = dictionary
+                .OnKeys(x => x.ToUpper())
+                .ToDictionary();
+
+            var expected = new Dictionary<string, int>
+            {
+                ["BURRITO"] = 8,
+                ["TACO"] = 6,
+                ["MARGARITA"] = 7,
+            };
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OnValues()
+        {
+            var dictionary = new Dictionary<string, int>
+            {
+                ["burrito"] = 8,
+                ["taco"] = 6,
+                ["margarita"] = 7,
+            };
+
+            var actual = dictionary
+                .OnValues(x => 2 * x)
+                .ToDictionary();
+
+            var expected = new Dictionary<string, int>
+            {
+                ["burrito"] = 16,
+                ["taco"] = 12,
+                ["margarita"] = 14
+            };
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Recore.Linq/LiftTests.cs
+++ b/test/Recore.Linq/LiftTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Xunit;
+
+namespace Recore.Linq.Tests
+{
+    public class LiftTests
+    {
+        [Fact]
+        public void ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.Lift<object>(null));
+        }
+
+        [Fact]
+        public void LiftAction()
+        {
+            int timesCalled = 0;
+            var lifted = Renumerable.Lift(
+                (int n) => { ++timesCalled; });
+
+            Assert.Equal(0, timesCalled);
+
+            var enumerable = Enumerable.Empty<int>();
+            lifted(enumerable);
+            Assert.Equal(0, timesCalled);
+
+            enumerable = new List<int> { 1, 2, 3, 4, 5 };
+            lifted(enumerable);
+            Assert.Equal(5, timesCalled);
+        }
+
+        [Fact]
+        public void LiftFunc()
+        {
+            var lifted = Renumerable.Lift(
+                (int n) => 1);
+
+            var enumerable = Enumerable.Empty<int>();
+            Assert.Empty(lifted(enumerable));
+
+            enumerable = new List<int> { 1, 2, 3, 4, 5 };
+            lifted(enumerable);
+            Assert.Equal(new List<int> { 1, 1, 1, 1, 1 }, lifted(enumerable));
+        }
+    }
+}

--- a/test/Recore.Linq/ToLinkedListTests.cs
+++ b/test/Recore.Linq/ToLinkedListTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Recore.Collections.Generic;
+
+using Xunit;
+
+namespace Recore.Linq.Tests
+{
+    public class ToLinkedListTests
+    {
+        [Fact]
+        public void ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Renumerable.ToLinkedList<object>(null));
+        }
+
+        [Fact]
+        public void ToLinkedList()
+        {
+            var actual = Enumerable.Range(1, 5).ToLinkedList();
+
+            Assert.Equal(new LinkedList<int> { 1, 2, 3, 4, 5 }, actual);
+        }
+    }
+}

--- a/test/Recore/EitherTests.cs
+++ b/test/Recore/EitherTests.cs
@@ -231,13 +231,19 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void LiftAction_ThrowsOnNull()
+        public void Lift_ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
                 () => Either.Lift<string, int>(null, x => { }));
 
             Assert.Throws<ArgumentNullException>(
                 () => Either.Lift<string, int>(x => { }, null));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Either.Lift<string, int, int>(null, x => 1));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Either.Lift<string, int, int>(x => 1, null));
         }
 
         [Fact]
@@ -249,6 +255,9 @@ namespace Recore.Tests
                 (string s) => { leftCalled = true; },
                 (int n) => { rightCalled = true; });
 
+            Assert.False(leftCalled);
+            Assert.False(rightCalled);
+
             Either<string, int> either;
 
             either = "hello";
@@ -259,16 +268,6 @@ namespace Recore.Tests
             either = 1;
             lifted(either);
             Assert.True(rightCalled);
-        }
-
-        [Fact]
-        public void LiftFunc_ThrowsOnNull()
-        {
-            Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int, int>(null, x => 1));
-
-            Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int, int>(x => 1, null));
         }
 
         [Fact]

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -423,6 +423,49 @@ namespace Recore.Tests
         }
 
         [Fact]
+        public void Lift_ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => Optional.Lift<string>(null));
+
+            Assert.Throws<ArgumentNullException>(
+                () => Optional.Lift<string, int>(null));
+        }
+
+        [Fact]
+        public void LiftAction()
+        {
+            bool called = false;
+            var lifted = Optional.Lift(
+                (string s) => { called = true; });
+
+            Assert.False(called);
+
+            var optional = Optional<string>.Empty;
+            lifted(optional);
+            Assert.False(called);
+
+            optional = "hello";
+            lifted(optional);
+            Assert.True(called);
+        }
+
+        [Fact]
+        public void LiftFunc()
+        {
+            var lifted = Optional.Lift(
+                (string s) => 1);
+
+            var optional = Optional<string>.Empty;
+            lifted(optional);
+            Assert.Equal(Optional<int>.Empty, lifted(optional));
+
+            optional = "hello";
+            lifted(optional);
+            Assert.Equal(1, lifted(optional));
+        }
+
+        [Fact]
         public void Flatten()
         {
             var doubleValue = new Optional<Optional<string>>("hello");


### PR DESCRIPTION
`OnKeys()` and `OnValues()` now throw `ArgumentNullException` when `func` is null instead of `NullReferenceException`