### PR TITLE
Add all of the Argmin / Argmax overloads

### DIFF
--- a/docs/design-notes/ArgminArgmax.md
+++ b/docs/design-notes/ArgminArgmax.md
@@ -8,3 +8,20 @@ Since you have to compute the max along the way, it saves you another trip throu
 to return the max.
 
 Of course, the ideal solution would have been for the built-in methods to just work like `Argmax` / `Argmin`.
+
+## Is `Argmax().Max` and `Argmin().Min` always equivalent to `Max()` and `Min()`?
+
+The short answer is yes, but there is a corner case.
+For the overloads that operate on a list of nullables,
+the `Max()` or `Min()` of an empty sequence is null,
+whereas for a list of value types, trying to call `Max()` or `Min()` on an empty sequence results in an `InvalidOperationException`.
+
+The confusing bit comes with the overloads that take a `selector` that returns a nullable value.
+The `Max()` or `Min()` of an empty sequence here is still null.
+But now, the input type is not necessarily nullable.
+One option is just to make the input type nullable to accommodate this one special case, but that complicates things quite a bit because you need to provide overloads for value and reference types separately.
+Another option is to return `default` in this case.
+This keeps the implementation the most similar to `Max()` and `Min()`, but doesn't make much sense when you actually hit that case.
+
+The best option in my opinion is to do what the generic `Max(IEnumerable<TSource>)` implementation does:
+if `TSource` is a value type, throw `InvalidOperationException`; if it is a reference type, return `null`.

--- a/docs/design-notes/ArgminArgmax.md
+++ b/docs/design-notes/ArgminArgmax.md
@@ -11,13 +11,17 @@ Of course, the ideal solution would have been for the built-in methods to just w
 
 ## Is `Argmax().Max` and `Argmin().Min` always equivalent to `Max()` and `Min()`?
 
-The short answer is yes, but there is a corner case.
+The short answer is yes, except for empty sequences.
 For the overloads that operate on a list of nullables,
-the `Max()` or `Min()` of an empty sequence is null,
+the `Max()` or `Min()` of an empty sequence is `null`,
 whereas for a list of value types, trying to call `Max()` or `Min()` on an empty sequence results in an `InvalidOperationException`.
 
-The confusing bit comes with the overloads that take a `selector` that returns a nullable value.
-The `Max()` or `Min()` of an empty sequence here is still null.
+The first edge case is with the overloads that don't take a `selector`.
+For `Max()` and `Min()`, whether these throw or return `null` depends on what `TSource` is.
+Since `Argmax()` or `Argmin()` returns the index here, it doesn't make sense to return `(0, null)` for an empty sequence, so these overloads just always throw `InvalidOperationException`.
+
+The other edge case is with the overloads that take a `selector` that returns a nullable value.
+The `Max()` or `Min()` of an empty sequence here is still `null`.
 But now, the input type is not necessarily nullable.
 One option is just to make the input type nullable to accommodate this one special case, but that complicates things quite a bit because you need to provide overloads for value and reference types separately.
 Another option is to return `default` in this case.
@@ -25,3 +29,5 @@ This keeps the implementation the most similar to `Max()` and `Min()`, but doesn
 
 The best option in my opinion is to do what the generic `Max(IEnumerable<TSource>)` implementation does:
 if `TSource` is a value type, throw `InvalidOperationException`; if it is a reference type, return `null`.
+
+So basically, `Argmax()` and `Argmin()` will return `null` for an empty sequence only if `selector` is passed and both `TSource` and `TResult` are nullable.

--- a/docs/design-notes/ArgminArgmax.md
+++ b/docs/design-notes/ArgminArgmax.md
@@ -17,7 +17,7 @@ the `Max()` or `Min()` of an empty sequence is `null`,
 whereas for a list of value types, trying to call `Max()` or `Min()` on an empty sequence results in an `InvalidOperationException`.
 
 The first edge case is with the overloads that don't take a `selector`.
-For `Max()` and `Min()`, whether these throw or return `null` depends on what `TSource` is.
+For `Max()` and `Min()`, whether these throw or return `null` depends on what the `T` in `IEnumerable<T>` is.
 Since `Argmax()` or `Argmin()` returns the index here, it doesn't make sense to return `(0, null)` for an empty sequence, so these overloads just always throw `InvalidOperationException`.
 
 The other edge case is with the overloads that take a `selector` that returns a nullable value.

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Recore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sequence contains no elements.
+        /// </summary>
+        internal static string NoElements {
+            get {
+                return ResourceManager.GetString("NoElements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An optional value was asserted to have a value, but was empty..
         /// </summary>
         internal static string OptionalAssertValue {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NoElements" xml:space="preserve">
+    <value>Sequence contains no elements</value>
+  </data>
   <data name="OptionalAssertValue" xml:space="preserve">
     <value>An optional value was asserted to have a value, but was empty.</value>
   </data>

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -15,7 +15,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, int Max) Argmax(this IEnumerable<int> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -47,7 +47,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, int? Max) Argmax(this IEnumerable<int?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -112,7 +112,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, long Max) Argmax(this IEnumerable<long> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -144,7 +144,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, long? Max) Argmax(this IEnumerable<long?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -203,7 +203,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, double Max) Argmax(this IEnumerable<double> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -250,7 +250,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, double? Max) Argmax(this IEnumerable<double?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -307,7 +307,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, float Max) Argmax(this IEnumerable<float> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -349,7 +349,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, float? Max) Argmax(this IEnumerable<float?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -406,7 +406,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, decimal Max) Argmax(this IEnumerable<decimal> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -438,7 +438,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmax, decimal? Max) Argmax(this IEnumerable<decimal?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -480,7 +480,7 @@ namespace Recore.Linq
         //[return: MaybeNull]
         public static (TSource Argmax, (int Argmax, TSource Max) Max) Argmax<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -541,12 +541,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, int Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -578,12 +578,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, int? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -648,12 +648,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, long Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -685,12 +685,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, long? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -749,12 +749,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, float Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -796,12 +796,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, float? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -858,12 +858,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, double Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -910,12 +910,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, double? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -972,12 +972,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, decimal Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -1009,12 +1009,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmax, decimal? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -1056,12 +1056,12 @@ namespace Recore.Linq
         //[return: MaybeNull]
         public static (TSource Argmax, TResult Max) Argmax<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -40,6 +40,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of nullable <see cref="int"/> values.
+        /// </summary>
         public static (int Argmax, int? Max) Argmax(this IEnumerable<int?> source)
         {
             if (source == null)
@@ -102,6 +105,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of <see cref="long"/> values.
+        /// </summary>
         public static (int Argmax, long Max) Argmax(this IEnumerable<long> source)
         {
             if (source == null)
@@ -131,6 +137,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of nullable <see cref="long"/> values.
+        /// </summary>
         public static (int Argmax, long? Max) Argmax(this IEnumerable<long?> source)
         {
             if (source == null)
@@ -187,6 +196,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of <see cref="double"/> values.
+        /// </summary>
         public static (int Argmax, double Max) Argmax(this IEnumerable<double> source)
         {
             if (source == null)
@@ -231,6 +243,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of nullable <see cref="double"/> values.
+        /// </summary>
         public static (int Argmax, double? Max) Argmax(this IEnumerable<double?> source)
         {
             if (source == null)
@@ -285,6 +300,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of <see cref="float"/> values.
+        /// </summary>
         public static (int Argmax, float Max) Argmax(this IEnumerable<float> source)
         {
             if (source == null)
@@ -324,6 +342,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of nullable <see cref="float"/> values.
+        /// </summary>
         public static (int Argmax, float? Max) Argmax(this IEnumerable<float?> source)
         {
             if (source == null)
@@ -378,6 +399,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of <see cref="decimal"/> values.
+        /// </summary>
         public static (int Argmax, decimal Max) Argmax(this IEnumerable<decimal> source)
         {
             if (source == null)
@@ -407,6 +431,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of nullable <see cref="decimal"/> values.
+        /// </summary>
         public static (int Argmax, decimal? Max) Argmax(this IEnumerable<decimal?> source)
         {
             if (source == null)
@@ -507,6 +534,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning <see cref="int"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, int Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
             if (source == null)
@@ -541,6 +571,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="int"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, int? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
             if (source == null)
@@ -608,6 +641,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning <see cref="long"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, long Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
             if (source == null)
@@ -642,6 +678,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="long"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, long? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
             if (source == null)
@@ -703,6 +742,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning <see cref="float"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, float Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
             if (source == null)
@@ -747,6 +789,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="float"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, float? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
             if (source == null)
@@ -806,6 +851,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning <see cref="double"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, double Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
             if (source == null)
@@ -855,6 +903,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="double"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, double? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
             if (source == null)
@@ -914,6 +965,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning <see cref="decimal"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, decimal Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
             if (source == null)
@@ -948,6 +1002,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="decimal"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmax, decimal? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
             if (source == null)
@@ -991,7 +1048,7 @@ namespace Recore.Linq
         }
 
         /// <summary>
-        /// Returns the maximum value and the maximizing value for a function from a sequence of values.
+        /// Returns the maximum value and the maximizing value for a function on a sequence of values.
         /// </summary>
         // TODO https://github.com/recorefx/RecoreFX/issues/24
         //[return: MaybeNull]

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -20,8 +20,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            int value;
-            using (IEnumerator<int> e = source.GetEnumerator())
+            (int Index, int Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -31,10 +31,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    int x = e.Current;
-                    if (x > value)
+                    if (e.Current.Item > value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -52,8 +51,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            int? value = null;
-            using (IEnumerator<int?> e = source.GetEnumerator())
+            (int Index, int? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -64,9 +63,9 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                int valueVal = value.GetValueOrDefault();
+                int valueVal = value.Item.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     // We can fast-path this case where we know HasValue will
@@ -77,8 +76,8 @@ namespace Recore.Linq
                     // uses, it's only been done in this direction for int? and long?.
                     while (e.MoveNext())
                     {
-                        int? cur = e.Current;
-                        int x = cur.GetValueOrDefault();
+                        var cur = e.Current;
+                        int x = cur.Item.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
@@ -90,12 +89,12 @@ namespace Recore.Linq
                 {
                     while (e.MoveNext())
                     {
-                        int? cur = e.Current;
-                        int x = cur.GetValueOrDefault();
+                        var cur = e.Current;
+                        int x = cur.Item.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.HasValue & x > valueVal)
+                        if (cur.Item.HasValue & x > valueVal)
                         {
                             valueVal = x;
                             value = cur;
@@ -117,8 +116,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            long value;
-            using (IEnumerator<long> e = source.GetEnumerator())
+            (int Index, long Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -128,10 +127,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    long x = e.Current;
-                    if (x > value)
+                    if (e.Current.Item > value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -149,8 +147,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            long? value = null;
-            using (IEnumerator<long?> e = source.GetEnumerator())
+            (int Index, long? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -161,15 +159,15 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                long valueVal = value.GetValueOrDefault();
+                long valueVal = value.Item.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     while (e.MoveNext())
                     {
-                        long? cur = e.Current;
-                        long x = cur.GetValueOrDefault();
+                        var cur = e.Current;
+                        long x = cur.Item.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
@@ -181,12 +179,12 @@ namespace Recore.Linq
                 {
                     while (e.MoveNext())
                     {
-                        long? cur = e.Current;
-                        long x = cur.GetValueOrDefault();
+                        var cur = e.Current;
+                        long x = cur.Item.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.HasValue & x > valueVal)
+                        if (cur.Item.HasValue & x > valueVal)
                         {
                             valueVal = x;
                             value = cur;
@@ -208,8 +206,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            double value;
-            using (IEnumerator<double> e = source.GetEnumerator())
+            (int Index, double Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -222,7 +220,7 @@ namespace Recore.Linq
                 // less than all other values. We need to do explicit checks to ensure this, but
                 // once we've found a value that is not NaN we need no longer worry about it,
                 // so first loop until such a value is found (or not, as the case may be).
-                while (double.IsNaN(value))
+                while (double.IsNaN(value.Item))
                 {
                     if (!e.MoveNext())
                     {
@@ -234,10 +232,9 @@ namespace Recore.Linq
 
                 while (e.MoveNext())
                 {
-                    double x = e.Current;
-                    if (x > value)
+                    if (e.Current.Item > value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -255,8 +252,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            double? value = null;
-            using (IEnumerator<double?> e = source.GetEnumerator())
+            (int Index, double? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -267,9 +264,9 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                double valueVal = value.GetValueOrDefault();
+                double valueVal = value.Item.GetValueOrDefault();
                 while (double.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -277,21 +274,22 @@ namespace Recore.Linq
                         return value;
                     }
 
-                    double? cur = e.Current;
-                    if (cur.HasValue)
+                    var cur = e.Current;
+                    if (cur.Item.HasValue)
                     {
-                        valueVal = (value = cur).GetValueOrDefault();
+                        value = cur;
+                        valueVal = value.Item.GetValueOrDefault();
                     }
                 }
 
                 while (e.MoveNext())
                 {
-                    double? cur = e.Current;
-                    double x = cur.GetValueOrDefault();
+                    var cur = e.Current;
+                    double x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x > valueVal)
+                    if (cur.Item.HasValue & x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -312,8 +310,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            float value;
-            using (IEnumerator<float> e = source.GetEnumerator())
+            (int Index, float Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -321,7 +319,7 @@ namespace Recore.Linq
                 }
 
                 value = e.Current;
-                while (float.IsNaN(value))
+                while (float.IsNaN(value.Item))
                 {
                     if (!e.MoveNext())
                     {
@@ -333,10 +331,9 @@ namespace Recore.Linq
 
                 while (e.MoveNext())
                 {
-                    float x = e.Current;
-                    if (x > value)
+                    if (e.Current.Item > value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -354,8 +351,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            float? value = null;
-            using (IEnumerator<float?> e = source.GetEnumerator())
+            (int Index, float? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -366,9 +363,9 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
+                float valueVal = value.Item.GetValueOrDefault();
                 while (float.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -376,21 +373,22 @@ namespace Recore.Linq
                         return value;
                     }
 
-                    float? cur = e.Current;
-                    if (cur.HasValue)
+                    var cur = e.Current;
+                    if (cur.Item.HasValue)
                     {
-                        valueVal = (value = cur).GetValueOrDefault();
+                        value = cur;
+                        valueVal = value.Item.GetValueOrDefault();
                     }
                 }
 
                 while (e.MoveNext())
                 {
-                    float? cur = e.Current;
-                    float x = cur.GetValueOrDefault();
+                    var cur = e.Current;
+                    float x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x > valueVal)
+                    if (cur.Item.HasValue & x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -411,8 +409,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            decimal value;
-            using (IEnumerator<decimal> e = source.GetEnumerator())
+            (int Index, decimal Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -422,10 +420,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    decimal x = e.Current;
-                    if (x > value)
+                    if (e.Current.Item > value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -443,8 +440,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            decimal? value = null;
-            using (IEnumerator<decimal?> e = source.GetEnumerator())
+            (int Index, decimal? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -455,14 +452,14 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                decimal valueVal = value.GetValueOrDefault();
+                decimal valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    decimal? cur = e.Current;
-                    decimal x = cur.GetValueOrDefault();
-                    if (cur.HasValue && x > valueVal)
+                    var cur = e.Current;
+                    decimal x = cur.Item.GetValueOrDefault();
+                    if (cur.Item.HasValue && x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -489,7 +486,7 @@ namespace Recore.Linq
             TSource value = default!;
             if (value == null)
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.Enumerate().GetEnumerator())
                 {
                     do
                     {
@@ -504,17 +501,16 @@ namespace Recore.Linq
 
                     while (e.MoveNext())
                     {
-                        TSource x = e.Current;
                         if (x != null && comparer.Compare(x, value) > 0)
                         {
-                            value = x;
+                            value = e.Current;
                         }
                     }
                 }
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.Enumerate().GetEnumerator())
                 {
                     if (!e.MoveNext())
                     {
@@ -524,10 +520,9 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        TSource x = e.Current;
                         if (comparer.Compare(x, value) > 0)
                         {
-                            value = x;
+                            value = e.Current;
                         }
                     }
                 }
@@ -552,7 +547,7 @@ namespace Recore.Linq
             }
 
             int value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -589,7 +584,7 @@ namespace Recore.Linq
             }
 
             int? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -600,9 +595,9 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                int valueVal = value.GetValueOrDefault();
+                int valueVal = value.Item.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     // We can fast-path this case where we know HasValue will
@@ -614,7 +609,7 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         int? cur = selector(e.Current);
-                        int x = cur.GetValueOrDefault();
+                        int x = cur.Item.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
@@ -627,11 +622,11 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         int? cur = selector(e.Current);
-                        int x = cur.GetValueOrDefault();
+                        int x = cur.Item.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.HasValue & x > valueVal)
+                        if (cur.Item.HasValue & x > valueVal)
                         {
                             valueVal = x;
                             value = cur;
@@ -659,7 +654,7 @@ namespace Recore.Linq
             }
 
             long value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -696,7 +691,7 @@ namespace Recore.Linq
             }
 
             long? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -707,15 +702,15 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                long valueVal = value.GetValueOrDefault();
+                long valueVal = value.Item.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     while (e.MoveNext())
                     {
                         long? cur = selector(e.Current);
-                        long x = cur.GetValueOrDefault();
+                        long x = cur.Item.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
@@ -728,11 +723,11 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         long? cur = selector(e.Current);
-                        long x = cur.GetValueOrDefault();
+                        long x = cur.Item.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.HasValue & x > valueVal)
+                        if (cur.Item.HasValue & x > valueVal)
                         {
                             valueVal = x;
                             value = cur;
@@ -760,7 +755,7 @@ namespace Recore.Linq
             }
 
             float value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -768,7 +763,7 @@ namespace Recore.Linq
                 }
 
                 value = selector(e.Current);
-                while (float.IsNaN(value))
+                while (float.IsNaN(value.Item))
                 {
                     if (!e.MoveNext())
                     {
@@ -807,7 +802,7 @@ namespace Recore.Linq
             }
 
             float? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -818,9 +813,9 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
+                float valueVal = value.Item.GetValueOrDefault();
                 while (float.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -829,7 +824,7 @@ namespace Recore.Linq
                     }
 
                     float? cur = selector(e.Current);
-                    if (cur.HasValue)
+                    if (cur.Item.HasValue)
                     {
                         valueVal = (value = cur).GetValueOrDefault();
                     }
@@ -838,11 +833,11 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
-                    float x = cur.GetValueOrDefault();
+                    float x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x > valueVal)
+                    if (cur.Item.HasValue & x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -869,7 +864,7 @@ namespace Recore.Linq
             }
 
             double value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -882,7 +877,7 @@ namespace Recore.Linq
                 // less than all other values. We need to do explicit checks to ensure this, but
                 // once we've found a value that is not NaN we need no longer worry about it,
                 // so first loop until such a value is found (or not, as the case may be).
-                while (double.IsNaN(value))
+                while (double.IsNaN(value.Item))
                 {
                     if (!e.MoveNext())
                     {
@@ -921,7 +916,7 @@ namespace Recore.Linq
             }
 
             double? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -932,9 +927,9 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                double valueVal = value.GetValueOrDefault();
+                double valueVal = value.Item.GetValueOrDefault();
                 while (double.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -943,7 +938,7 @@ namespace Recore.Linq
                     }
 
                     double? cur = selector(e.Current);
-                    if (cur.HasValue)
+                    if (cur.Item.HasValue)
                     {
                         valueVal = (value = cur).GetValueOrDefault();
                     }
@@ -952,11 +947,11 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);
-                    double x = cur.GetValueOrDefault();
+                    double x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x > valueVal)
+                    if (cur.Item.HasValue & x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -983,7 +978,7 @@ namespace Recore.Linq
             }
 
             decimal value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -1020,7 +1015,7 @@ namespace Recore.Linq
             }
 
             decimal? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -1031,14 +1026,14 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                decimal valueVal = value.GetValueOrDefault();
+                decimal valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     decimal? cur = selector(e.Current);
-                    decimal x = cur.GetValueOrDefault();
-                    if (cur.HasValue && x > valueVal)
+                    decimal x = cur.Item.GetValueOrDefault();
+                    if (cur.Item.HasValue && x > valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -1070,7 +1065,7 @@ namespace Recore.Linq
             TResult value = default!;
             if (value == null)
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.GetEnumerator())
                 {
                     do
                     {
@@ -1095,7 +1090,7 @@ namespace Recore.Linq
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.GetEnumerator())
                 {
                     if (!e.MoveNext())
                     {

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -548,6 +548,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             int value;
             using (var e = source.GetEnumerator())
             {
@@ -556,12 +557,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argmaxCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     int x = selector(e.Current);
                     if (x > value)
                     {
+                        argmaxCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -585,6 +588,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -595,11 +599,12 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                int valueVal = value.Item.GetValueOrDefault();
+                int valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     // We can fast-path this case where we know HasValue will
@@ -611,10 +616,11 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         int? cur = selector(e.Current);
-                        int x = cur.Item.GetValueOrDefault();
+                        int x = cur.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
+                            argmaxCandidate = e.Current;
                             value = cur;
                         }
                     }
@@ -624,13 +630,14 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         int? cur = selector(e.Current);
-                        int x = cur.Item.GetValueOrDefault();
+                        int x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.Item.HasValue & x > valueVal)
+                        if (cur.HasValue & x > valueVal)
                         {
                             valueVal = x;
+                            argmaxCandidate = e.Current;
                             value = cur;
                         }
                     }
@@ -655,6 +662,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             long value;
             using (var e = source.GetEnumerator())
             {
@@ -663,12 +671,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argmaxCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     long x = selector(e.Current);
                     if (x > value)
                     {
+                        argmaxCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -692,6 +702,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -702,20 +713,22 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                long valueVal = value.Item.GetValueOrDefault();
+                long valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
                     while (e.MoveNext())
                     {
                         long? cur = selector(e.Current);
-                        long x = cur.Item.GetValueOrDefault();
+                        long x = cur.GetValueOrDefault();
                         if (x > valueVal)
                         {
                             valueVal = x;
+                            argmaxCandidate = e.Current;
                             value = cur;
                         }
                     }
@@ -725,13 +738,14 @@ namespace Recore.Linq
                     while (e.MoveNext())
                     {
                         long? cur = selector(e.Current);
-                        long x = cur.Item.GetValueOrDefault();
+                        long x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
-                        if (cur.Item.HasValue & x > valueVal)
+                        if (cur.HasValue & x > valueVal)
                         {
                             valueVal = x;
+                            argmaxCandidate = e.Current;
                             value = cur;
                         }
                     }
@@ -756,6 +770,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             float value;
             using (var e = source.GetEnumerator())
             {
@@ -764,8 +779,9 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argmaxCandidate = e.Current;
                 value = selector(e.Current);
-                while (float.IsNaN(value.Item))
+                while (float.IsNaN(value))
                 {
                     if (!e.MoveNext())
                     {
@@ -780,6 +796,7 @@ namespace Recore.Linq
                     float x = selector(e.Current);
                     if (x > value)
                     {
+                        argmaxCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -803,6 +820,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -813,11 +831,12 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                float valueVal = value.Item.GetValueOrDefault();
+                float valueVal = value.GetValueOrDefault();
                 while (float.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -826,8 +845,9 @@ namespace Recore.Linq
                     }
 
                     float? cur = selector(e.Current);
-                    if (cur.Item.HasValue)
+                    if (cur.HasValue)
                     {
+                        argmaxCandidate = e.Current;
                         valueVal = (value = cur).GetValueOrDefault();
                     }
                 }
@@ -835,13 +855,14 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
-                    float x = cur.Item.GetValueOrDefault();
+                    float x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.Item.HasValue & x > valueVal)
+                    if (cur.HasValue & x > valueVal)
                     {
                         valueVal = x;
+                        argmaxCandidate = e.Current;
                         value = cur;
                     }
                 }
@@ -865,6 +886,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             double value;
             using (var e = source.GetEnumerator())
             {
@@ -873,13 +895,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argmaxCandidate = e.Current;
                 value = selector(e.Current);
 
                 // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
                 // less than all other values. We need to do explicit checks to ensure this, but
                 // once we've found a value that is not NaN we need no longer worry about it,
                 // so first loop until such a value is found (or not, as the case may be).
-                while (double.IsNaN(value.Item))
+                while (double.IsNaN(value))
                 {
                     if (!e.MoveNext())
                     {
@@ -894,6 +917,7 @@ namespace Recore.Linq
                     double x = selector(e.Current);
                     if (x > value)
                     {
+                        argmaxCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -917,6 +941,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -927,11 +952,12 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                double valueVal = value.Item.GetValueOrDefault();
+                double valueVal = value.GetValueOrDefault();
                 while (double.IsNaN(valueVal))
                 {
                     if (!e.MoveNext())
@@ -940,8 +966,9 @@ namespace Recore.Linq
                     }
 
                     double? cur = selector(e.Current);
-                    if (cur.Item.HasValue)
+                    if (cur.HasValue)
                     {
+                        argmaxCandidate = e.Current;
                         valueVal = (value = cur).GetValueOrDefault();
                     }
                 }
@@ -949,13 +976,14 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);
-                    double x = cur.Item.GetValueOrDefault();
+                    double x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.Item.HasValue & x > valueVal)
+                    if (cur.HasValue & x > valueVal)
                     {
                         valueVal = x;
+                        argmaxCandidate = e.Current;
                         value = cur;
                     }
                 }
@@ -979,6 +1007,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             decimal value;
             using (var e = source.GetEnumerator())
             {
@@ -987,12 +1016,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argmaxCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     decimal x = selector(e.Current);
                     if (x > value)
                     {
+                        argmaxCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -1016,6 +1047,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argmaxCandidate;
             decimal? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -1026,18 +1058,20 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                decimal valueVal = value.Item.GetValueOrDefault();
+                decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     decimal? cur = selector(e.Current);
-                    decimal x = cur.Item.GetValueOrDefault();
-                    if (cur.Item.HasValue && x > valueVal)
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x > valueVal)
                     {
                         valueVal = x;
+                        argmaxCandidate = e.Current;
                         value = cur;
                     }
                 }
@@ -1066,6 +1100,7 @@ namespace Recore.Linq
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TResult value = default!;
+            TSource argmaxCandidate;
             TResult value = default;
             if (value == null)
             {
@@ -1078,6 +1113,7 @@ namespace Recore.Linq
                             return value;
                         }
 
+                        argmaxCandidate = e.Current;
                         value = selector(e.Current);
                     }
                     while (value == null);
@@ -1087,6 +1123,7 @@ namespace Recore.Linq
                         TResult x = selector(e.Current);
                         if (x != null && comparer.Compare(x, value) > 0)
                         {
+                            argmaxCandidate = e.Current;
                             value = x;
                         }
                     }
@@ -1101,12 +1138,14 @@ namespace Recore.Linq
                         throw new InvalidOperationException(Resources.NoElements);
                     }
 
+                    argmaxCandidate = e.Current;
                     value = selector(e.Current);
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
                         if (comparer.Compare(x, value) > 0)
                         {
+                            argmaxCandidate = e.Current;
                             value = x;
                         }
                     }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -483,7 +483,9 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            TSource value = default!;
+            // TODO https://github.com/recorefx/RecoreFX/issues/24
+            //TSource value = default!;
+            TSource value = default;
             if (value == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
@@ -1062,7 +1064,9 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            TResult value = default!;
+            // TODO https://github.com/recorefx/RecoreFX/issues/24
+            //TResult value = default!;
+            TResult value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -1,121 +1,1061 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+// TODO https://github.com/recorefx/RecoreFX/issues/24
+//using System.Diagnostics.CodeAnalysis;
 
 namespace Recore.Linq
 {
+    // Adapted from https://github.com/dotnet/runtime/blob/809a06f45161ae686a06b9e9ccc2f45097b91657/src/libraries/System.Linq/src/System/Linq/Max.cs
     public static partial class Renumerable
     {
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+        /// <summary>
+        /// Returns the maximum value and the index of the maximum value from a sequence of <see cref="int"/> values.
+        /// </summary>
+        public static (int Argmax, int Max) Argmax(this IEnumerable<int> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+            int value;
+            using (IEnumerator<int> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    int x = e.Current;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+            return value;
+        }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+        public static (int Argmax, int? Max) Argmax(this IEnumerable<int?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+            int? value = null;
+            using (IEnumerator<int?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+                    value = e.Current;
+                }
+                while (!value.HasValue);
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+                int valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    // We can fast-path this case where we know HasValue will
+                    // never affect the outcome, without constantly checking
+                    // if we're in such a state. Similar fast-paths could
+                    // be done for other cases, but as all-positive
+                    // or mostly-positive integer values are quite common in real-world
+                    // uses, it's only been done in this direction for int? and long?.
+                    while (e.MoveNext())
+                    {
+                        int? cur = e.Current;
+                        int x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        int? cur = e.Current;
+                        int x = cur.GetValueOrDefault();
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
 
-        // public static TSource Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
+            return value;
+        }
+
+        public static (int Argmax, long Max) Argmax(this IEnumerable<long> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            long value;
+            using (IEnumerator<long> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    long x = e.Current;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, long? Max) Argmax(this IEnumerable<long?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            long? value = null;
+            using (IEnumerator<long?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                long valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = e.Current;
+                        long x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = e.Current;
+                        long x = cur.GetValueOrDefault();
+
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, double Max) Argmax(this IEnumerable<double> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            double value;
+            using (IEnumerator<double> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+
+                // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
+                // less than all other values. We need to do explicit checks to ensure this, but
+                // once we've found a value that is not NaN we need no longer worry about it,
+                // so first loop until such a value is found (or not, as the case may be).
+                while (double.IsNaN(value))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+
+                while (e.MoveNext())
+                {
+                    double x = e.Current;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, double? Max) Argmax(this IEnumerable<double?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            double? value = null;
+            using (IEnumerator<double?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                double valueVal = value.GetValueOrDefault();
+                while (double.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    double? cur = e.Current;
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
+                }
+
+                while (e.MoveNext())
+                {
+                    double? cur = e.Current;
+                    double x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, float Max) Argmax(this IEnumerable<float> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            float value;
+            using (IEnumerator<float> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (float.IsNaN(value))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+
+                while (e.MoveNext())
+                {
+                    float x = e.Current;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, float? Max) Argmax(this IEnumerable<float?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            float? value = null;
+            using (IEnumerator<float?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                float valueVal = value.GetValueOrDefault();
+                while (float.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    float? cur = e.Current;
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
+                }
+
+                while (e.MoveNext())
+                {
+                    float? cur = e.Current;
+                    float x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, decimal Max) Argmax(this IEnumerable<decimal> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            decimal value;
+            using (IEnumerator<decimal> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    decimal x = e.Current;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmax, decimal? Max) Argmax(this IEnumerable<decimal?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            decimal? value = null;
+            using (IEnumerator<decimal?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = e.Current;
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
 
         /// <summary>
-        /// Returns the maximum value and the index of the maximum value for a function from a sequence of values.
+        /// Returns the maximum value and the index of the maximum value from a sequence of values.
         /// </summary>
-        public static (int Argmax, TSource Max) Argmax<TSource>(this IEnumerable<TSource> source)
+        // TODO https://github.com/recorefx/RecoreFX/issues/24
+        //[return: MaybeNull]
+        public static (TSource Argmax, (int Argmax, TSource Max) Max) Argmax<TSource>(this IEnumerable<TSource> source)
         {
-            var argmax = source
-                .Enumerate()
-                .Argmax(pair => pair.Item);
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
 
-            return (Argmax: argmax.Argmax.Index, argmax.Max);
+            Comparer<TSource> comparer = Comparer<TSource>.Default;
+            TSource value = default!;
+            if (value == null)
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    do
+                    {
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
+                        value = e.Current;
+                    }
+                    while (value == null);
+
+                    while (e.MoveNext())
+                    {
+                        TSource x = e.Current;
+                        if (x != null && comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = e.Current;
+                    while (e.MoveNext())
+                    {
+                        TSource x = e.Current;
+                        if (comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, int Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            int value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    int x = selector(e.Current);
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, int? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            int? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                int valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    // We can fast-path this case where we know HasValue will
+                    // never affect the outcome, without constantly checking
+                    // if we're in such a state. Similar fast-paths could
+                    // be done for other cases, but as all-positive
+                    // or mostly-positive integer values are quite common in real-world
+                    // uses, it's only been done in this direction for int? and long?.
+                    while (e.MoveNext())
+                    {
+                        int? cur = selector(e.Current);
+                        int x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        int? cur = selector(e.Current);
+                        int x = cur.GetValueOrDefault();
+
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, long Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            long value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    long x = selector(e.Current);
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, long? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            long? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                long valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = selector(e.Current);
+                        long x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = selector(e.Current);
+                        long x = cur.GetValueOrDefault();
+
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, float Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            float value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (float.IsNaN(value))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+
+                while (e.MoveNext())
+                {
+                    float x = selector(e.Current);
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, float? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            float? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                float valueVal = value.GetValueOrDefault();
+                while (float.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    float? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
+                }
+
+                while (e.MoveNext())
+                {
+                    float? cur = selector(e.Current);
+                    float x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, double Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            double value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+
+                // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
+                // less than all other values. We need to do explicit checks to ensure this, but
+                // once we've found a value that is not NaN we need no longer worry about it,
+                // so first loop until such a value is found (or not, as the case may be).
+                while (double.IsNaN(value))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+
+                while (e.MoveNext())
+                {
+                    double x = selector(e.Current);
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, double? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            double? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                double valueVal = value.GetValueOrDefault();
+                while (double.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    double? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
+                }
+
+                while (e.MoveNext())
+                {
+                    double? cur = selector(e.Current);
+                    double x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, decimal Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            decimal value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    decimal x = selector(e.Current);
+                    if (x > value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmax, decimal? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            decimal? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = selector(e.Current);
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
         }
 
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function from a sequence of values.
         /// </summary>
+        // TODO https://github.com/recorefx/RecoreFX/issues/24
+        //[return: MaybeNull]
         public static (TSource Argmax, TResult Max) Argmax<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source is null)
+            if (source == null)
             {
-                throw new ArgumentNullException(nameof(source));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector is null)
+            if (selector == null)
             {
-                throw new ArgumentNullException(nameof(selector));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            using (var enumerator = source.GetEnumerator())
+            Comparer<TResult> comparer = Comparer<TResult>.Default;
+            TResult value = default!;
+            if (value == null)
             {
-                // No elements
-                if (!enumerator.MoveNext())
+                using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (default(TSource) == null)
+                    do
                     {
-                        // Reference type
-                        return default;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
+                        value = selector(e.Current);
                     }
-                    else
+                    while (value == null);
+
+                    while (e.MoveNext())
                     {
-                        // Value type
-                        throw new InvalidOperationException(); // TODO message
+                        TResult x = selector(e.Current);
+                        if (x != null && comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
-
-                // Initialize with first element
-                var argmax = enumerator.Current;
-                var max = selector(enumerator.Current);
-                var comparer = Comparer<TResult>.Default;
-                while (enumerator.MoveNext())
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    var value = selector(enumerator.Current);
-                    if (comparer.Compare(value, max) > 0)
+                    if (!e.MoveNext())
                     {
-                        max = value;
-                        argmax = enumerator.Current;
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = selector(e.Current);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
-
-                return (argmax, max);
             }
+
+            return value;
         }
     }
 }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -588,17 +588,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argmaxCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argmaxCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -702,17 +711,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argmaxCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argmaxCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -820,17 +838,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argmaxCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argmaxCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -941,17 +968,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argmaxCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argmaxCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -1047,17 +1083,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             decimal? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argmaxCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argmaxCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argmaxCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -1100,19 +1145,28 @@ namespace Recore.Linq
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TResult value = default!;
-            TSource argmaxCandidate;
+            TSource argmaxCandidate = default;
             TResult value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())
                 {
+                    bool isEmpty = true;
                     do
                     {
                         if (!e.MoveNext())
                         {
-                            return (argmaxCandidate, value);
+                            if (isEmpty && default(TSource) != null)
+                            {
+                                throw new InvalidOperationException(Resources.NoElements);
+                            }
+                            else
+                            {
+                                return (argmaxCandidate, value);
+                            }
                         }
 
+                        isEmpty = false;
                         argmaxCandidate = e.Current;
                         value = selector(e.Current);
                     }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -570,7 +570,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -596,7 +596,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     argmaxCandidate = e.Current;
@@ -644,7 +644,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -684,7 +684,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -710,7 +710,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     argmaxCandidate = e.Current;
@@ -752,7 +752,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -785,7 +785,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     value = selector(e.Current);
@@ -802,7 +802,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -828,7 +828,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     argmaxCandidate = e.Current;
@@ -841,7 +841,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     float? cur = selector(e.Current);
@@ -868,7 +868,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -906,7 +906,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     value = selector(e.Current);
@@ -923,7 +923,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -949,7 +949,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     argmaxCandidate = e.Current;
@@ -962,7 +962,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     double? cur = selector(e.Current);
@@ -989,7 +989,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -1029,7 +1029,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -1055,7 +1055,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argmaxCandidate, value);
                     }
 
                     argmaxCandidate = e.Current;
@@ -1077,7 +1077,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
 
         /// <summary>
@@ -1110,7 +1110,7 @@ namespace Recore.Linq
                     {
                         if (!e.MoveNext())
                         {
-                            return value;
+                            return (argmaxCandidate, value);
                         }
 
                         argmaxCandidate = e.Current;
@@ -1152,7 +1152,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argmaxCandidate, value);
         }
     }
 }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 // TODO https://github.com/recorefx/RecoreFX/issues/24
 //using System.Diagnostics.CodeAnalysis;
 
+using Recore.Properties;
+
 namespace Recore.Linq
 {
     // Adapted from https://github.com/dotnet/runtime/blob/809a06f45161ae686a06b9e9ccc2f45097b91657/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -15,7 +17,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             int value;
@@ -23,7 +25,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -47,7 +49,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             int? value = null;
@@ -112,7 +114,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             long value;
@@ -120,7 +122,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -144,7 +146,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             long? value = null;
@@ -203,7 +205,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             double value;
@@ -211,7 +213,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -250,7 +252,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             double? value = null;
@@ -307,7 +309,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             float value;
@@ -315,7 +317,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -349,7 +351,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             float? value = null;
@@ -406,7 +408,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             decimal value;
@@ -414,7 +416,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -438,7 +440,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             decimal? value = null;
@@ -480,7 +482,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
@@ -516,7 +518,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        ThrowHelper.ThrowNoElementsException();
+                        throw new InvalidOperationException(Resources.NoElements);
                     }
 
                     value = e.Current;
@@ -541,12 +543,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             int value;
@@ -554,7 +556,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -578,12 +580,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             int? value = null;
@@ -648,12 +650,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             long value;
@@ -661,7 +663,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -685,12 +687,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             long? value = null;
@@ -749,12 +751,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             float value;
@@ -762,7 +764,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -796,12 +798,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             float? value = null;
@@ -858,12 +860,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             double value;
@@ -871,7 +873,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -910,12 +912,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             double? value = null;
@@ -972,12 +974,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             decimal value;
@@ -985,7 +987,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -1009,12 +1011,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             decimal? value = null;
@@ -1056,12 +1058,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
@@ -1097,7 +1099,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        ThrowHelper.ThrowNoElementsException();
+                        throw new InvalidOperationException(Resources.NoElements);
                     }
 
                     value = selector(e.Current);

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -475,7 +475,7 @@ namespace Recore.Linq
         /// </summary>
         // TODO https://github.com/recorefx/RecoreFX/issues/24
         //[return: MaybeNull]
-        public static (TSource Argmax, (int Argmax, TSource Max) Max) Argmax<TSource>(this IEnumerable<TSource> source)
+        public static (int Argmax, TSource Max) Argmax<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
             {
@@ -485,8 +485,8 @@ namespace Recore.Linq
             Comparer<TSource> comparer = Comparer<TSource>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TSource value = default!;
-            TSource value = default;
-            if (value == null)
+            (int Index, TSource Item) value = (0, default);
+            if (value.Item == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
                 {
@@ -499,11 +499,11 @@ namespace Recore.Linq
 
                         value = e.Current;
                     }
-                    while (value == null);
+                    while (value.Item == null);
 
                     while (e.MoveNext())
                     {
-                        if (x != null && comparer.Compare(x, value) > 0)
+                        if (e.Current.Item != null && comparer.Compare(e.Current.Item, value.Item) > 0)
                         {
                             value = e.Current;
                         }
@@ -522,7 +522,7 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        if (comparer.Compare(x, value) > 0)
+                        if (comparer.Compare(e.Current.Item, value.Item) > 0)
                         {
                             value = e.Current;
                         }

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -54,13 +54,22 @@ namespace Recore.Linq
             (int Index, int? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -150,13 +159,22 @@ namespace Recore.Linq
             (int Index, long? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -255,13 +273,22 @@ namespace Recore.Linq
             (int Index, double? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -354,13 +381,22 @@ namespace Recore.Linq
             (int Index, float? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -443,13 +479,22 @@ namespace Recore.Linq
             (int Index, decimal? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -490,13 +535,22 @@ namespace Recore.Linq
             {
                 using (var e = source.Enumerate().GetEnumerator())
                 {
+                    bool isEmpty = true;
                     do
                     {
                         if (!e.MoveNext())
                         {
-                            return value;
+                            if (isEmpty)
+                            {
+                                throw new InvalidOperationException(Resources.NoElements);
+                            }
+                            else
+                            {
+                                return value;
+                            }
                         }
 
+                        isEmpty = false;
                         value = e.Current;
                     }
                     while (value.Item == null);

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -504,6 +504,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             int value;
             using (var e = source.GetEnumerator())
             {
@@ -512,12 +513,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argminCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     int x = selector(e.Current);
                     if (x < value)
                     {
+                        argminCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -541,6 +544,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -553,21 +557,22 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
-                int valueVal = value.Item.GetValueOrDefault();
+                int valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     int? cur = selector(e.Current);
-                    int x = cur.Item.GetValueOrDefault();
+                    int x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.Item.HasValue & x < valueVal)
+                    if (cur.HasValue & x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -593,6 +598,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             long value;
             using (var e = source.GetEnumerator())
             {
@@ -601,12 +607,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argminCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     long x = selector(e.Current);
                     if (x < value)
                     {
+                        argminCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -630,6 +638,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -640,21 +649,23 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                long valueVal = value.Item.GetValueOrDefault();
+                long valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     long? cur = selector(e.Current);
-                    long x = cur.Item.GetValueOrDefault();
+                    long x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.Item.HasValue & x < valueVal)
+                    if (cur.HasValue & x < valueVal)
                     {
                         valueVal = x;
+                        argminCandidate = e.Current;
                         value = cur;
                     }
                 }
@@ -678,6 +689,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             float value;
             using (var e = source.GetEnumerator())
             {
@@ -686,8 +698,9 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argminCandidate = e.Current;
                 value = selector(e.Current);
-                if (float.IsNaN(value.Item))
+                if (float.IsNaN(value))
                 {
                     return value;
                 }
@@ -697,6 +710,7 @@ namespace Recore.Linq
                     float x = selector(e.Current);
                     if (x < value)
                     {
+                        argminCandidate = e.Current;
                         value = x;
                     }
 
@@ -733,6 +747,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -743,11 +758,12 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                float valueVal = value.Item.GetValueOrDefault();
+                float valueVal = value.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
                     return value;
@@ -756,12 +772,13 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
-                    if (cur.Item.HasValue)
+                    if (cur.HasValue)
                     {
-                        float x = cur.Item.GetValueOrDefault();
+                        float x = cur.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
+                            argminCandidate = e.Current;
                             value = cur;
                         }
                         else if (float.IsNaN(x))
@@ -790,6 +807,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             double value;
             using (var e = source.GetEnumerator())
             {
@@ -798,6 +816,7 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argminCandidate = e.Current;
                 value = selector(e.Current);
                 if (double.IsNaN(value.Item))
                 {
@@ -809,6 +828,7 @@ namespace Recore.Linq
                     double x = selector(e.Current);
                     if (x < value)
                     {
+                        argminCandidate = e.Current;
                         value = x;
                     }
                     else if (double.IsNaN(x))
@@ -836,6 +856,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -846,11 +867,12 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                double valueVal = value.Item.GetValueOrDefault();
+                double valueVal = value.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
                     return value;
@@ -859,12 +881,13 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);
-                    if (cur.Item.HasValue)
+                    if (cur.HasValue)
                     {
-                        double x = cur.Item.GetValueOrDefault();
+                        double x = cur.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
+                            argminCandidate = e.Current;
                             value = cur;
                         }
                         else if (double.IsNaN(x))
@@ -893,6 +916,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             decimal value;
             using (var e = source.GetEnumerator())
             {
@@ -901,12 +925,14 @@ namespace Recore.Linq
                     throw new InvalidOperationException(Resources.NoElements);
                 }
 
+                argminCandidate = e.Current;
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     decimal x = selector(e.Current);
                     if (x < value)
                     {
+                        argminCandidate = e.Current;
                         value = x;
                     }
                 }
@@ -930,6 +956,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
+            TSource argminCandidate;
             decimal? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -940,18 +967,20 @@ namespace Recore.Linq
                         return value;
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
-                while (!value.Item.HasValue);
+                while (!value.HasValue);
 
-                decimal valueVal = value.Item.GetValueOrDefault();
+                decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     decimal? cur = selector(e.Current);
-                    decimal x = cur.Item.GetValueOrDefault();
-                    if (cur.Item.HasValue && x < valueVal)
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x < valueVal)
                     {
                         valueVal = x;
+                        argminCandidate = e.Current;
                         value = cur;
                     }
                 }
@@ -980,6 +1009,7 @@ namespace Recore.Linq
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TResult value = default!;
+            TSource argminCandidate;
             TResult value = default;
             if (value == null)
             {
@@ -992,6 +1022,7 @@ namespace Recore.Linq
                             return value;
                         }
 
+                        argminCandidate = e.Current;
                         value = selector(e.Current);
                     }
                     while (value == null);
@@ -1001,6 +1032,7 @@ namespace Recore.Linq
                         TResult x = selector(e.Current);
                         if (x != null && comparer.Compare(x, value) < 0)
                         {
+                            argminCandidate = e.Current;
                             value = x;
                         }
                     }
@@ -1015,12 +1047,14 @@ namespace Recore.Linq
                         throw new InvalidOperationException(Resources.NoElements);
                     }
 
+                    argminCandidate = e.Current;
                     value = selector(e.Current);
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
                         if (comparer.Compare(x, value) < 0)
                         {
+                            argminCandidate = e.Current;
                             value = x;
                         }
                     }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -54,15 +54,25 @@ namespace Recore.Linq
             (int Index, int? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
+
                 // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                 // so we don't have to keep testing for nullity.
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -132,13 +142,22 @@ namespace Recore.Linq
             (int Index, long? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -224,13 +243,22 @@ namespace Recore.Linq
             (int Index, float? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -316,13 +344,22 @@ namespace Recore.Linq
             (int Index, double? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -399,13 +436,22 @@ namespace Recore.Linq
             (int Index, decimal? Item) value = (0, null);
             using (var e = source.Enumerate().GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        if (isEmpty)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
 
+                    isEmpty = false;
                     value = e.Current;
                 }
                 while (!value.Item.HasValue);
@@ -446,13 +492,22 @@ namespace Recore.Linq
             {
                 using (var e = source.Enumerate().GetEnumerator())
                 {
+                    bool isEmpty = true;
                     do
                     {
                         if (!e.MoveNext())
                         {
-                            return value;
+                            if (isEmpty)
+                            {
+                                throw new InvalidOperationException(Resources.NoElements);
+                            }
+                            else
+                            {
+                                return value;
+                            }
                         }
 
+                        isEmpty = false;
                         value = e.Current;
                     }
                     while (value.Item == null);

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -439,7 +439,9 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            TSource value = default!;
+            // TODO https://github.com/recorefx/RecoreFX/issues/24
+            //TSource value = default!;
+            TSource value = default;
             if (value == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
@@ -976,7 +978,9 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            TResult value = default!;
+            // TODO https://github.com/recorefx/RecoreFX/issues/24
+            //TResult value = default!;
+            TResult value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -431,7 +431,7 @@ namespace Recore.Linq
         /// </summary>
         // TODO https://github.com/recorefx/RecoreFX/issues/24
         //[return: MaybeNull]
-        public static (TSource Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
+        public static (int Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
             {
@@ -441,8 +441,8 @@ namespace Recore.Linq
             Comparer<TSource> comparer = Comparer<TSource>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TSource value = default!;
-            TSource value = default;
-            if (value == null)
+            (int Index, TSource Item) value = (0, default);
+            if (value.Item == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
                 {
@@ -455,11 +455,11 @@ namespace Recore.Linq
 
                         value = e.Current;
                     }
-                    while (value == null);
+                    while (value.Item == null);
 
                     while (e.MoveNext())
                     {
-                        if (x != null && comparer.Compare(x, value) < 0)
+                        if (e.Current.Item != null && comparer.Compare(e.Current.Item, value.Item) < 0)
                         {
                             value = e.Current;
                         }
@@ -478,7 +478,7 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        if (comparer.Compare(x, value) < 0)
+                        if (comparer.Compare(e.Current.Item, value.Item) < 0)
                         {
                             value = e.Current;
                         }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -15,7 +15,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, int Min) Argmin(this IEnumerable<int> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -47,7 +47,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, int? Min) Argmin(this IEnumerable<int?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -94,7 +94,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, long Min) Argmin(this IEnumerable<long> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -126,7 +126,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, long? Min) Argmin(this IEnumerable<long?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -169,7 +169,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, float Min) Argmin(this IEnumerable<float> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -219,7 +219,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, float? Min) Argmin(this IEnumerable<float?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -271,7 +271,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, double Min) Argmin(this IEnumerable<double> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -312,7 +312,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, double? Min) Argmin(this IEnumerable<double?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -364,7 +364,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, decimal Min) Argmin(this IEnumerable<decimal> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -396,7 +396,7 @@ namespace Recore.Linq
         /// </summary>
         public static (int Argmin, decimal? Min) Argmin(this IEnumerable<decimal?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -438,7 +438,7 @@ namespace Recore.Linq
         //[return: MaybeNull]
         public static (TSource Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -499,12 +499,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, int Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -536,12 +536,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, int? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -588,12 +588,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, long Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -625,12 +625,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, long? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -673,12 +673,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, float Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -728,12 +728,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, float? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -785,12 +785,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, double Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -831,12 +831,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, double? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -888,12 +888,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, decimal Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -925,12 +925,12 @@ namespace Recore.Linq
         /// </summary>
         public static (TSource Argmin, decimal? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }
@@ -972,12 +972,12 @@ namespace Recore.Linq
         //[return: MaybeNull]
         public static (TSource Argmin, TResult Min) Argmin<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 throw new ArgumentNullException(nameof(selector));
             }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -526,7 +526,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argminCandidate, value);
                     }
 
                     argminCandidate = e.Current;
@@ -580,7 +580,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -620,7 +620,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -646,7 +646,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argminCandidate, value);
                     }
 
                     argminCandidate = e.Current;
@@ -671,7 +671,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -702,7 +702,7 @@ namespace Recore.Linq
                 value = selector(e.Current);
                 if (float.IsNaN(value))
                 {
-                    return value;
+                    return (argminCandidate, value);
                 }
 
                 while (e.MoveNext())
@@ -724,12 +724,12 @@ namespace Recore.Linq
                     // can't find a smaller value, we can short-circuit.
                     else if (float.IsNaN(x))
                     {
-                        return x;
+                        return (e.Current, x);
                     }
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -755,7 +755,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argminCandidate, value);
                     }
 
                     argminCandidate = e.Current;
@@ -766,7 +766,7 @@ namespace Recore.Linq
                 float valueVal = value.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
-                    return value;
+                    return (argminCandidate, value);
                 }
 
                 while (e.MoveNext())
@@ -783,13 +783,13 @@ namespace Recore.Linq
                         }
                         else if (float.IsNaN(x))
                         {
-                            return cur;
+                            return (e.Current, cur);
                         }
                     }
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -818,9 +818,9 @@ namespace Recore.Linq
 
                 argminCandidate = e.Current;
                 value = selector(e.Current);
-                if (double.IsNaN(value.Item))
+                if (double.IsNaN(value))
                 {
-                    return value;
+                    return (argminCandidate, value);
                 }
 
                 while (e.MoveNext())
@@ -833,12 +833,12 @@ namespace Recore.Linq
                     }
                     else if (double.IsNaN(x))
                     {
-                        return x;
+                        return (e.Current, x);
                     }
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -864,7 +864,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argminCandidate, value);
                     }
 
                     argminCandidate = e.Current;
@@ -875,7 +875,7 @@ namespace Recore.Linq
                 double valueVal = value.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
-                    return value;
+                    return (argminCandidate, value);
                 }
 
                 while (e.MoveNext())
@@ -892,13 +892,13 @@ namespace Recore.Linq
                         }
                         else if (double.IsNaN(x))
                         {
-                            return cur;
+                            return (e.Current, cur);
                         }
                     }
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -938,7 +938,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -964,7 +964,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return value;
+                        return (argminCandidate, value);
                     }
 
                     argminCandidate = e.Current;
@@ -986,7 +986,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
 
         /// <summary>
@@ -1019,7 +1019,7 @@ namespace Recore.Linq
                     {
                         if (!e.MoveNext())
                         {
-                            return value;
+                            return (argminCandidate, value);
                         }
 
                         argminCandidate = e.Current;
@@ -1061,7 +1061,7 @@ namespace Recore.Linq
                 }
             }
 
-            return value;
+            return (argminCandidate, value);
         }
     }
 }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -20,8 +20,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            int value;
-            using (IEnumerator<int> e = source.GetEnumerator())
+            (int Index, int Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -31,10 +31,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    int x = e.Current;
-                    if (x < value)
+                    if (e.Current.Item < value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -52,8 +51,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            int? value = null;
-            using (IEnumerator<int?> e = source.GetEnumerator())
+            (int Index, int? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                 // so we don't have to keep testing for nullity.
@@ -66,19 +65,19 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
-                int valueVal = value.GetValueOrDefault();
+                int valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    int? cur = e.Current;
-                    int x = cur.GetValueOrDefault();
+                    var cur = e.Current;
+                    int x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
+                    if (cur.Item.HasValue & x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -99,8 +98,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            long value;
-            using (IEnumerator<long> e = source.GetEnumerator())
+            (int Index, long Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -110,10 +109,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    long x = e.Current;
-                    if (x < value)
+                    if (e.Current.Item < value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -131,8 +129,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            long? value = null;
-            using (IEnumerator<long?> e = source.GetEnumerator())
+            (int Index, long? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -143,17 +141,17 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                long valueVal = value.GetValueOrDefault();
+                long valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    long? cur = e.Current;
-                    long x = cur.GetValueOrDefault();
+                    var cur = e.Current;
+                    long x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
+                    if (cur.Item.HasValue & x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -174,8 +172,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            float value;
-            using (IEnumerator<float> e = source.GetEnumerator())
+            (int Index, float Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -183,17 +181,16 @@ namespace Recore.Linq
                 }
 
                 value = e.Current;
-                if (float.IsNaN(value))
+                if (float.IsNaN(value.Item))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    float x = e.Current;
-                    if (x < value)
+                    if (e.Current.Item < value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
 
                     // Normally NaN < anything is false, as is anything < NaN
@@ -204,9 +201,9 @@ namespace Recore.Linq
                     // negative infinity.
                     // Not testing for NaN therefore isn't an option, but since we
                     // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x))
+                    else if (float.IsNaN(e.Current.Item))
                     {
-                        return x;
+                        return e.Current;
                     }
                 }
             }
@@ -224,8 +221,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            float? value = null;
-            using (IEnumerator<float?> e = source.GetEnumerator())
+            (int Index, float? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -236,9 +233,9 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
+                float valueVal = value.Item.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
                     return value;
@@ -246,10 +243,10 @@ namespace Recore.Linq
 
                 while (e.MoveNext())
                 {
-                    float? cur = e.Current;
-                    if (cur.HasValue)
+                    var cur = e.Current;
+                    if (cur.Item.HasValue)
                     {
-                        float x = cur.GetValueOrDefault();
+                        float x = cur.Item.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
@@ -276,8 +273,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            double value;
-            using (IEnumerator<double> e = source.GetEnumerator())
+            (int Index, double Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -285,21 +282,20 @@ namespace Recore.Linq
                 }
 
                 value = e.Current;
-                if (double.IsNaN(value))
+                if (double.IsNaN(value.Item))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    double x = e.Current;
-                    if (x < value)
+                    if (e.Current.Item < value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
-                    else if (double.IsNaN(x))
+                    else if (double.IsNaN(e.Current.Item))
                     {
-                        return x;
+                        return e.Current;
                     }
                 }
             }
@@ -317,8 +313,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            double? value = null;
-            using (IEnumerator<double?> e = source.GetEnumerator())
+            (int Index, double? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -329,9 +325,9 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                double valueVal = value.GetValueOrDefault();
+                double valueVal = value.Item.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
                     return value;
@@ -339,10 +335,10 @@ namespace Recore.Linq
 
                 while (e.MoveNext())
                 {
-                    double? cur = e.Current;
-                    if (cur.HasValue)
+                    var cur = e.Current;
+                    if (cur.Item.HasValue)
                     {
-                        double x = cur.GetValueOrDefault();
+                        double x = cur.Item.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
@@ -369,8 +365,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            decimal value;
-            using (IEnumerator<decimal> e = source.GetEnumerator())
+            (int Index, decimal Item) value;
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -380,10 +376,9 @@ namespace Recore.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    decimal x = e.Current;
-                    if (x < value)
+                    if (e.Current.Item < value.Item)
                     {
-                        value = x;
+                        value = e.Current;
                     }
                 }
             }
@@ -401,8 +396,8 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(source));
             }
 
-            decimal? value = null;
-            using (IEnumerator<decimal?> e = source.GetEnumerator())
+            (int Index, decimal? Item) value = (0, null);
+            using (var e = source.Enumerate().GetEnumerator())
             {
                 do
                 {
@@ -413,14 +408,14 @@ namespace Recore.Linq
 
                     value = e.Current;
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                decimal valueVal = value.GetValueOrDefault();
+                decimal valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    decimal? cur = e.Current;
-                    decimal x = cur.GetValueOrDefault();
-                    if (cur.HasValue && x < valueVal)
+                    var cur = e.Current;
+                    decimal x = cur.Item.GetValueOrDefault();
+                    if (cur.Item.HasValue && x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -447,7 +442,7 @@ namespace Recore.Linq
             TSource value = default!;
             if (value == null)
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.Enumerate().GetEnumerator())
                 {
                     do
                     {
@@ -462,17 +457,16 @@ namespace Recore.Linq
 
                     while (e.MoveNext())
                     {
-                        TSource x = e.Current;
                         if (x != null && comparer.Compare(x, value) < 0)
                         {
-                            value = x;
+                            value = e.Current;
                         }
                     }
                 }
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.Enumerate().GetEnumerator())
                 {
                     if (!e.MoveNext())
                     {
@@ -482,10 +476,9 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        TSource x = e.Current;
                         if (comparer.Compare(x, value) < 0)
                         {
-                            value = x;
+                            value = e.Current;
                         }
                     }
                 }
@@ -510,7 +503,7 @@ namespace Recore.Linq
             }
 
             int value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -547,7 +540,7 @@ namespace Recore.Linq
             }
 
             int? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                 // so we don't have to keep testing for nullity.
@@ -560,19 +553,19 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
-                int valueVal = value.GetValueOrDefault();
+                int valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     int? cur = selector(e.Current);
-                    int x = cur.GetValueOrDefault();
+                    int x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
+                    if (cur.Item.HasValue & x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -599,7 +592,7 @@ namespace Recore.Linq
             }
 
             long value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -636,7 +629,7 @@ namespace Recore.Linq
             }
 
             long? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -647,17 +640,17 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                long valueVal = value.GetValueOrDefault();
+                long valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     long? cur = selector(e.Current);
-                    long x = cur.GetValueOrDefault();
+                    long x = cur.Item.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
+                    if (cur.Item.HasValue & x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -684,7 +677,7 @@ namespace Recore.Linq
             }
 
             float value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -692,7 +685,7 @@ namespace Recore.Linq
                 }
 
                 value = selector(e.Current);
-                if (float.IsNaN(value))
+                if (float.IsNaN(value.Item))
                 {
                     return value;
                 }
@@ -739,7 +732,7 @@ namespace Recore.Linq
             }
 
             float? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -750,9 +743,9 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
+                float valueVal = value.Item.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
                     return value;
@@ -761,9 +754,9 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
-                    if (cur.HasValue)
+                    if (cur.Item.HasValue)
                     {
-                        float x = cur.GetValueOrDefault();
+                        float x = cur.Item.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
@@ -796,7 +789,7 @@ namespace Recore.Linq
             }
 
             double value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -804,7 +797,7 @@ namespace Recore.Linq
                 }
 
                 value = selector(e.Current);
-                if (double.IsNaN(value))
+                if (double.IsNaN(value.Item))
                 {
                     return value;
                 }
@@ -842,7 +835,7 @@ namespace Recore.Linq
             }
 
             double? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -853,9 +846,9 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                double valueVal = value.GetValueOrDefault();
+                double valueVal = value.Item.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
                     return value;
@@ -864,9 +857,9 @@ namespace Recore.Linq
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);
-                    if (cur.HasValue)
+                    if (cur.Item.HasValue)
                     {
-                        double x = cur.GetValueOrDefault();
+                        double x = cur.Item.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
@@ -899,7 +892,7 @@ namespace Recore.Linq
             }
 
             decimal value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -936,7 +929,7 @@ namespace Recore.Linq
             }
 
             decimal? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            using (var e = source.GetEnumerator())
             {
                 do
                 {
@@ -947,14 +940,14 @@ namespace Recore.Linq
 
                     value = selector(e.Current);
                 }
-                while (!value.HasValue);
+                while (!value.Item.HasValue);
 
-                decimal valueVal = value.GetValueOrDefault();
+                decimal valueVal = value.Item.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     decimal? cur = selector(e.Current);
-                    decimal x = cur.GetValueOrDefault();
-                    if (cur.HasValue && x < valueVal)
+                    decimal x = cur.Item.GetValueOrDefault();
+                    if (cur.Item.HasValue && x < valueVal)
                     {
                         valueVal = x;
                         value = cur;
@@ -986,7 +979,7 @@ namespace Recore.Linq
             TResult value = default!;
             if (value == null)
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.GetEnumerator())
                 {
                     do
                     {
@@ -1011,7 +1004,7 @@ namespace Recore.Linq
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                using (var e = source.GetEnumerator())
                 {
                     if (!e.MoveNext())
                     {

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 // TODO https://github.com/recorefx/RecoreFX/issues/24
 //using System.Diagnostics.CodeAnalysis;
 
+using Recore.Properties;
+
 namespace Recore.Linq
 {
     // https://github.com/dotnet/runtime/blob/809a06f45161ae686a06b9e9ccc2f45097b91657/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -15,7 +17,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             int value;
@@ -23,7 +25,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -47,7 +49,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             int? value = null;
@@ -94,7 +96,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             long value;
@@ -102,7 +104,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -126,7 +128,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             long? value = null;
@@ -169,7 +171,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             float value;
@@ -177,7 +179,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -219,7 +221,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             float? value = null;
@@ -271,7 +273,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             double value;
@@ -279,7 +281,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -312,7 +314,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             double? value = null;
@@ -364,7 +366,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             decimal value;
@@ -372,7 +374,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = e.Current;
@@ -396,7 +398,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             decimal? value = null;
@@ -438,7 +440,7 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
@@ -474,7 +476,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        ThrowHelper.ThrowNoElementsException();
+                        throw new InvalidOperationException(Resources.NoElements);
                     }
 
                     value = e.Current;
@@ -499,12 +501,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             int value;
@@ -512,7 +514,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -536,12 +538,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             int? value = null;
@@ -588,12 +590,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             long value;
@@ -601,7 +603,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -625,12 +627,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             long? value = null;
@@ -673,12 +675,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             float value;
@@ -686,7 +688,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -728,12 +730,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             float? value = null;
@@ -785,12 +787,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             double value;
@@ -798,7 +800,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -831,12 +833,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             double? value = null;
@@ -888,12 +890,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             decimal value;
@@ -901,7 +903,7 @@ namespace Recore.Linq
             {
                 if (!e.MoveNext())
                 {
-                    ThrowHelper.ThrowNoElementsException();
+                    throw new InvalidOperationException(Resources.NoElements);
                 }
 
                 value = selector(e.Current);
@@ -925,12 +927,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             decimal? value = null;
@@ -972,12 +974,12 @@ namespace Recore.Linq
         {
             if (source == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (selector == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+                throw new ArgumentNullException(nameof(selector));
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
@@ -1013,7 +1015,7 @@ namespace Recore.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        ThrowHelper.ThrowNoElementsException();
+                        throw new InvalidOperationException(Resources.NoElements);
                     }
 
                     value = selector(e.Current);

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -544,19 +544,28 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                 // so we don't have to keep testing for nullity.
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argminCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argminCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -638,17 +647,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argminCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argminCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -747,17 +765,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argminCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argminCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -856,17 +883,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argminCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argminCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -956,17 +992,26 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             decimal? value = null;
             using (var e = source.GetEnumerator())
             {
+                bool isEmpty = true;
                 do
                 {
                     if (!e.MoveNext())
                     {
-                        return (argminCandidate, value);
+                        if (isEmpty && default(TSource) != null)
+                        {
+                            throw new InvalidOperationException(Resources.NoElements);
+                        }
+                        else
+                        {
+                            return (argminCandidate, value);
+                        }
                     }
 
+                    isEmpty = false;
                     argminCandidate = e.Current;
                     value = selector(e.Current);
                 }
@@ -1009,19 +1054,28 @@ namespace Recore.Linq
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             // TODO https://github.com/recorefx/RecoreFX/issues/24
             //TResult value = default!;
-            TSource argminCandidate;
+            TSource argminCandidate = default;
             TResult value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())
                 {
+                    bool isEmpty = true;
                     do
                     {
                         if (!e.MoveNext())
                         {
-                            return (argminCandidate, value);
+                            if (isEmpty && default(TSource) != null)
+                            {
+                                throw new InvalidOperationException(Resources.NoElements);
+                            }
+                            else
+                            {
+                                return (argminCandidate, value);
+                            }
                         }
 
+                        isEmpty = false;
                         argminCandidate = e.Current;
                         value = selector(e.Current);
                     }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -1,120 +1,971 @@
 using System;
 using System.Collections.Generic;
+// TODO https://github.com/recorefx/RecoreFX/issues/24
+//using System.Diagnostics.CodeAnalysis;
 
 namespace Recore.Linq
 {
+    // https://github.com/dotnet/runtime/blob/809a06f45161ae686a06b9e9ccc2f45097b91657/src/libraries/System.Linq/src/System/Linq/Min.cs
     public static partial class Renumerable
     {
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        // public static TSource Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
-        // {
-        //     return source.GetEnumerator().Current;
-        // }
-
-        /// <summary>
-        /// Returns the minimum value and the index of the minimum value for a function from a sequence of values.
-        /// </summary>
-        public static (int Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
+        public static (int Argmin, int Min) Argmin(this IEnumerable<int> source)
         {
-            var argmin = source
-                .Enumerate()
-                .Argmin(pair => pair.Item);
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
 
-            return (Argmin: argmin.Argmin.Index, argmin.Min);
+            int value;
+            using (IEnumerator<int> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    int x = e.Current;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, int? Min) Argmin(this IEnumerable<int?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            int? value = null;
+            using (IEnumerator<int?> e = source.GetEnumerator())
+            {
+                // Start off knowing that we've a non-null value (or exit here, knowing we don't)
+                // so we don't have to keep testing for nullity.
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                // Keep hold of the wrapped value, and do comparisons on that, rather than
+                // using the lifted operation each time.
+                int valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    int? cur = e.Current;
+                    int x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, long Min) Argmin(this IEnumerable<long> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            long value;
+            using (IEnumerator<long> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    long x = e.Current;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, long? Min) Argmin(this IEnumerable<long?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            long? value = null;
+            using (IEnumerator<long?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                long valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    long? cur = e.Current;
+                    long x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, float Min) Argmin(this IEnumerable<float> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            float value;
+            using (IEnumerator<float> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                if (float.IsNaN(value))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    float x = e.Current;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+
+                    // Normally NaN < anything is false, as is anything < NaN
+                    // However, this leads to some irksome outcomes in Min and Max.
+                    // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                    // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                    // ordering where NaN is smaller than every value, including
+                    // negative infinity.
+                    // Not testing for NaN therefore isn't an option, but since we
+                    // can't find a smaller value, we can short-circuit.
+                    else if (float.IsNaN(x))
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, float? Min) Argmin(this IEnumerable<float?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            float? value = null;
+            using (IEnumerator<float?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                float valueVal = value.GetValueOrDefault();
+                if (float.IsNaN(valueVal))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    float? cur = e.Current;
+                    if (cur.HasValue)
+                    {
+                        float x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (float.IsNaN(x))
+                        {
+                            return cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, double Min) Argmin(this IEnumerable<double> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            double value;
+            using (IEnumerator<double> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                if (double.IsNaN(value))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    double x = e.Current;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                    else if (double.IsNaN(x))
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, double? Min) Argmin(this IEnumerable<double?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            double? value = null;
+            using (IEnumerator<double?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                double valueVal = value.GetValueOrDefault();
+                if (double.IsNaN(valueVal))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    double? cur = e.Current;
+                    if (cur.HasValue)
+                    {
+                        double x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (double.IsNaN(x))
+                        {
+                            return cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, decimal Min) Argmin(this IEnumerable<decimal> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            decimal value;
+            using (IEnumerator<decimal> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = e.Current;
+                while (e.MoveNext())
+                {
+                    decimal x = e.Current;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (int Argmin, decimal? Min) Argmin(this IEnumerable<decimal?> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            decimal? value = null;
+            using (IEnumerator<decimal?> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = e.Current;
+                }
+                while (!value.HasValue);
+
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = e.Current;
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        // TODO https://github.com/recorefx/RecoreFX/issues/24
+        //[return: MaybeNull]
+        public static (TSource Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            Comparer<TSource> comparer = Comparer<TSource>.Default;
+            TSource value = default!;
+            if (value == null)
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    do
+                    {
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
+                        value = e.Current;
+                    }
+                    while (value == null);
+
+                    while (e.MoveNext())
+                    {
+                        TSource x = e.Current;
+                        if (x != null && comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = e.Current;
+                    while (e.MoveNext())
+                    {
+                        TSource x = e.Current;
+                        if (comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, int Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            int value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    int x = selector(e.Current);
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, int? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            int? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                // Start off knowing that we've a non-null value (or exit here, knowing we don't)
+                // so we don't have to keep testing for nullity.
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                // Keep hold of the wrapped value, and do comparisons on that, rather than
+                // using the lifted operation each time.
+                int valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    int? cur = selector(e.Current);
+                    int x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, long Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            long value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    long x = selector(e.Current);
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, long? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            long? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                long valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    long? cur = selector(e.Current);
+                    long x = cur.GetValueOrDefault();
+
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, float Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            float value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                if (float.IsNaN(value))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    float x = selector(e.Current);
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+
+                    // Normally NaN < anything is false, as is anything < NaN
+                    // However, this leads to some irksome outcomes in Min and Max.
+                    // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                    // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                    // ordering where NaN is smaller than every value, including
+                    // negative infinity.
+                    // Not testing for NaN therefore isn't an option, but since we
+                    // can't find a smaller value, we can short-circuit.
+                    else if (float.IsNaN(x))
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, float? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            float? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                float valueVal = value.GetValueOrDefault();
+                if (float.IsNaN(valueVal))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    float? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        float x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (float.IsNaN(x))
+                        {
+                            return cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, double Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            double value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                if (double.IsNaN(value))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    double x = selector(e.Current);
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                    else if (double.IsNaN(x))
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, double? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            double? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                double valueVal = value.GetValueOrDefault();
+                if (double.IsNaN(valueVal))
+                {
+                    return value;
+                }
+
+                while (e.MoveNext())
+                {
+                    double? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        double x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (double.IsNaN(x))
+                        {
+                            return cur;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, decimal Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            decimal value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    decimal x = selector(e.Current);
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static (TSource Argmin, decimal? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (selector == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
+            }
+
+            decimal? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
+                    value = selector(e.Current);
+                }
+                while (!value.HasValue);
+
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = selector(e.Current);
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+
+            return value;
         }
 
         /// <summary>
         /// Returns the minimum and the minimizing value for a function from a sequence of values.
         /// </summary>
+        // TODO https://github.com/recorefx/RecoreFX/issues/24
+        //[return: MaybeNull]
         public static (TSource Argmin, TResult Min) Argmin<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source is null)
+            if (source == null)
             {
-                throw new ArgumentNullException(nameof(source));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector is null)
+            if (selector == null)
             {
-                throw new ArgumentNullException(nameof(selector));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            using (var enumerator = source.GetEnumerator())
+            Comparer<TResult> comparer = Comparer<TResult>.Default;
+            TResult value = default!;
+            if (value == null)
             {
-                // No elements
-                if (!enumerator.MoveNext())
+                using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (default(TSource) == null)
+                    do
                     {
-                        // Reference type
-                        return default;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
+                        value = selector(e.Current);
                     }
-                    else
+                    while (value == null);
+
+                    while (e.MoveNext())
                     {
-                        // Value type
-                        throw new InvalidOperationException(); // TODO message
+                        TResult x = selector(e.Current);
+                        if (x != null && comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
-
-                // Initialize with first element
-                var argmin = enumerator.Current;
-                var min = selector(enumerator.Current);
-                var comparer = Comparer<TResult>.Default;
-                while (enumerator.MoveNext())
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    var value = selector(enumerator.Current);
-                    if (comparer.Compare(value, min) < 0)
+                    if (!e.MoveNext())
                     {
-                        min = value;
-                        argmin = enumerator.Current;
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = selector(e.Current);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
-
-                return (argmin, min);
             }
+
+            return value;
         }
     }
 }

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -8,6 +8,9 @@ namespace Recore.Linq
     // https://github.com/dotnet/runtime/blob/809a06f45161ae686a06b9e9ccc2f45097b91657/src/libraries/System.Linq/src/System/Linq/Min.cs
     public static partial class Renumerable
     {
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of <see cref="int"/> values.
+        /// </summary>
         public static (int Argmin, int Min) Argmin(this IEnumerable<int> source)
         {
             if (source == null)
@@ -37,6 +40,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of nullable <see cref="int"/> values.
+        /// </summary>
         public static (int Argmin, int? Min) Argmin(this IEnumerable<int?> source)
         {
             if (source == null)
@@ -81,6 +87,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of <see cref="long"/> values.
+        /// </summary>
         public static (int Argmin, long Min) Argmin(this IEnumerable<long> source)
         {
             if (source == null)
@@ -110,6 +119,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of nullable <see cref="long"/> values.
+        /// </summary>
         public static (int Argmin, long? Min) Argmin(this IEnumerable<long?> source)
         {
             if (source == null)
@@ -150,6 +162,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of <see cref="float"/> values.
+        /// </summary>
         public static (int Argmin, float Min) Argmin(this IEnumerable<float> source)
         {
             if (source == null)
@@ -197,6 +212,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of nullable <see cref="float"/> values.
+        /// </summary>
         public static (int Argmin, float? Min) Argmin(this IEnumerable<float?> source)
         {
             if (source == null)
@@ -246,6 +264,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of <see cref="double"/> values.
+        /// </summary>
         public static (int Argmin, double Min) Argmin(this IEnumerable<double> source)
         {
             if (source == null)
@@ -284,6 +305,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of nullable <see cref="double"/> values.
+        /// </summary>
         public static (int Argmin, double? Min) Argmin(this IEnumerable<double?> source)
         {
             if (source == null)
@@ -333,6 +357,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of <see cref="decimal"/> values.
+        /// </summary>
         public static (int Argmin, decimal Min) Argmin(this IEnumerable<decimal> source)
         {
             if (source == null)
@@ -362,6 +389,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of nullable <see cref="decimal"/> values.
+        /// </summary>
         public static (int Argmin, decimal? Min) Argmin(this IEnumerable<decimal?> source)
         {
             if (source == null)
@@ -399,6 +429,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the index of the minimum value from a sequence of values.
+        /// </summary>
         // TODO https://github.com/recorefx/RecoreFX/issues/24
         //[return: MaybeNull]
         public static (TSource Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
@@ -459,6 +492,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning <see cref="int"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, int Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
             if (source == null)
@@ -493,6 +529,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="int"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, int? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
             if (source == null)
@@ -542,6 +581,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning <see cref="long"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, long Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
             if (source == null)
@@ -576,6 +618,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="long"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, long? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
             if (source == null)
@@ -621,6 +666,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning <see cref="float"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, float Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
             if (source == null)
@@ -673,6 +721,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="float"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, float? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
             if (source == null)
@@ -727,6 +778,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning <see cref="double"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, double Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
             if (source == null)
@@ -770,6 +824,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="double"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, double? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
             if (source == null)
@@ -824,6 +881,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="decimal"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, decimal Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
             if (source == null)
@@ -858,6 +918,9 @@ namespace Recore.Linq
             return value;
         }
 
+        /// <summary>
+        /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="decimal"/> on a sequence of values.
+        /// </summary>
         public static (TSource Argmin, decimal? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
             if (source == null)
@@ -901,7 +964,7 @@ namespace Recore.Linq
         }
 
         /// <summary>
-        /// Returns the minimum and the minimizing value for a function from a sequence of values.
+        /// Returns the minimum value and the minimizing value for a function on a sequence of values.
         /// </summary>
         // TODO https://github.com/recorefx/RecoreFX/issues/24
         //[return: MaybeNull]

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -193,10 +193,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -23,10 +23,23 @@ namespace Recore.Linq.Tests
         [Fact]
         public void EmptyEnumerable()
         {
-            // Nullable types return null
-            Assert.Null(Enumerable.Empty<string>().Argmax(x => x.GetHashCode()).Argmax);
+            // Non-nullable TSource throws
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<int>().Argmax().Argmax);
 
-            // Non-nullable types throw
+            // Nullable TSource returns 0
+            Assert.Equal(0, Enumerable.Empty<string>().Argmax().Argmax);
+
+            // Nullable TSource and TResult returns null
+            Assert.Null(Enumerable.Empty<string>().Argmax(x => x.ToUpper()).Argmax);
+
+            // When one or both of TSource and TResult is non-nullable, throws
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<string>().Argmax(x => x.Length).Argmax);
+
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<int>().Argmax(x => string.Empty).Argmax);
+
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmax(x => x * x));
         }

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -27,11 +27,8 @@ namespace Recore.Linq.Tests
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmax().Argmax);
 
-            // Nullable TSource returns 0
-            Assert.Equal(0, Enumerable.Empty<string>().Argmax().Argmax);
-
-            // Nullable TSource and TResult returns null
-            Assert.Null(Enumerable.Empty<string>().Argmax(x => x.ToUpper()).Argmax);
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<string>().Argmax().Argmax);
 
             // When one or both of TSource and TResult is non-nullable, throws
             Assert.Throws<InvalidOperationException>(
@@ -42,6 +39,9 @@ namespace Recore.Linq.Tests
 
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmax(x => x * x));
+
+            // When both of TSource and TResult are non-nullable, returns null
+            Assert.Null(Enumerable.Empty<string>().Argmax(x => x.ToUpper()).Argmax);
         }
 
         [Fact]
@@ -141,9 +141,18 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -175,9 +184,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -209,9 +226,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -243,9 +268,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -277,9 +310,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -290,9 +331,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
     }
 }

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -102,9 +102,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_Int32(List<int> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -115,7 +121,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_NullableInt32(List<int?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -128,9 +134,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_Int64(List<long> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -141,7 +153,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_NullableInt64(List<long?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -154,9 +166,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_Double(List<double> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -167,7 +185,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_NullableDouble(List<double?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -180,9 +198,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_Single(List<float> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -193,7 +217,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_NullableSingle(List<float?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -206,9 +230,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_Decimal(List<decimal> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -219,7 +249,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_NullableDecimal(List<decimal?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -232,7 +262,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MaxAlwaysEqualsEnumerableMax_String(List<string> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -98,5 +98,148 @@ namespace Recore.Linq.Tests
             var (argmax, max) = xs.Argmax(x => x);
             Assert.Equal(max, argmax);
         }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Int32(List<int> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_NullableInt32(List<int?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Int64(List<long> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_NullableInt64(List<long?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Double(List<double> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_NullableDouble(List<double?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Single(List<float> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_NullableSingle(List<float?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Decimal(List<decimal> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_NullableDecimal(List<decimal?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_String(List<string> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Max(),
+                collection.Argmax().Max);
+        }
     }
 }

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -112,10 +112,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -144,10 +146,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -208,10 +212,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -240,10 +246,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Max(),
-                collection.Argmax().Max);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -141,7 +141,6 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-
             if (collection.Count == 0)
             {
                 Assert.Null(collection.Max());
@@ -341,6 +340,248 @@ namespace Recore.Linq.Tests
                 Assert.Equal(
                     collection.Max(),
                     collection.Argmax().Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_Int32(List<int> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_NullableInt32(List<int?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_Int64(List<long> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_NullableInt64(List<long?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_Double(List<double> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_NullableDouble(List<double?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_Single(List<float> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_NullableSingle(List<float?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_Decimal(List<decimal> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_NullableDecimal(List<decimal?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
+            }
+        }
+
+        [Property]
+        public void MaxAlwaysEqualsEnumerableMax_Selector_String(List<string> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Max(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmax(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Max(x => projected[x]),
+                    source.Argmax(x => projected[x]).Max);
             }
         }
     }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -23,15 +23,12 @@ namespace Recore.Linq.Tests
         [Fact]
         public void EmptyEnumerable()
         {
-            // Non-nullable TSource throws
+            // With no selector, always throws
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmin().Argmin);
 
-            // Nullable TSource returns 0
-            Assert.Equal(0, Enumerable.Empty<string>().Argmin().Argmin);
-
-            // Nullable TSource and TResult returns null
-            Assert.Null(Enumerable.Empty<string>().Argmin(x => x.ToUpper()).Argmin);
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<string>().Argmin().Argmin);
 
             // When one or both of TSource and TResult is non-nullable, throws
             Assert.Throws<InvalidOperationException>(
@@ -42,6 +39,9 @@ namespace Recore.Linq.Tests
 
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmin(x => x * x));
+
+            // When both of TSource and TResult are non-nullable, returns null
+            Assert.Null(Enumerable.Empty<string>().Argmin(x => x.ToUpper()).Argmin);
         }
 
         [Fact]
@@ -141,9 +141,18 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
 
         [Property]
@@ -175,9 +184,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
 
         [Property]
@@ -209,9 +226,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
 
         [Property]
@@ -243,9 +268,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
 
         [Property]
@@ -277,9 +310,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
 
         [Property]
@@ -290,9 +331,17 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            if (collection.Count == 0)
+            {
+                Assert.Null(collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
+            }
+            else
+            {
+                Assert.Equal(
+                    collection.Min(),
+                    collection.Argmin().Min);
+            }
         }
     }
 }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -112,10 +112,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -144,10 +146,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -176,10 +180,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -208,10 +214,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]
@@ -240,10 +248,12 @@ namespace Recore.Linq.Tests
                 Assert.Throws<InvalidOperationException>(() => collection.Max());
                 Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
-
-            Assert.Equal(
-                collection.Min(),
-                collection.Argmin().Min);
+            else
+            {
+                Assert.Equal(
+                    collection.Max(),
+                    collection.Argmax().Max);
+            }
         }
 
         [Property]

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -102,9 +102,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_Int32(List<int> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -115,7 +121,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_NullableInt32(List<int?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -128,9 +134,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_Int64(List<long> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -141,7 +153,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_NullableInt64(List<long?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -154,9 +166,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_Double(List<double> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -167,7 +185,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_NullableDouble(List<double?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -180,9 +198,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_Single(List<float> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -193,7 +217,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_NullableSingle(List<float?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -206,9 +230,15 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_Decimal(List<decimal> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
+            }
+
+            if (collection.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => collection.Max());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
             }
 
             Assert.Equal(
@@ -219,7 +249,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_NullableDecimal(List<decimal?> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }
@@ -232,7 +262,7 @@ namespace Recore.Linq.Tests
         [Property]
         public void MinAlwaysEqualsEnumerableMin_String(List<string> collection)
         {
-            if (collection is null || collection.Count == 0)
+            if (collection is null)
             {
                 return;
             }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -122,14 +122,14 @@ namespace Recore.Linq.Tests
 
             if (collection.Count == 0)
             {
-                Assert.Throws<InvalidOperationException>(() => collection.Max());
-                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+                Assert.Throws<InvalidOperationException>(() => collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
             }
             else
             {
                 Assert.Equal(
-                    collection.Max(),
-                    collection.Argmax().Max);
+                    collection.Min(),
+                    collection.Argmin().Min);
             }
         }
 
@@ -156,14 +156,14 @@ namespace Recore.Linq.Tests
 
             if (collection.Count == 0)
             {
-                Assert.Throws<InvalidOperationException>(() => collection.Max());
-                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+                Assert.Throws<InvalidOperationException>(() => collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
             }
             else
             {
                 Assert.Equal(
-                    collection.Max(),
-                    collection.Argmax().Max);
+                    collection.Min(),
+                    collection.Argmin().Min);
             }
         }
 
@@ -190,14 +190,14 @@ namespace Recore.Linq.Tests
 
             if (collection.Count == 0)
             {
-                Assert.Throws<InvalidOperationException>(() => collection.Max());
-                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+                Assert.Throws<InvalidOperationException>(() => collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
             }
             else
             {
                 Assert.Equal(
-                    collection.Max(),
-                    collection.Argmax().Max);
+                    collection.Min(),
+                    collection.Argmin().Min);
             }
         }
 
@@ -224,14 +224,14 @@ namespace Recore.Linq.Tests
 
             if (collection.Count == 0)
             {
-                Assert.Throws<InvalidOperationException>(() => collection.Max());
-                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+                Assert.Throws<InvalidOperationException>(() => collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
             }
             else
             {
                 Assert.Equal(
-                    collection.Max(),
-                    collection.Argmax().Max);
+                    collection.Min(),
+                    collection.Argmin().Min);
             }
         }
 
@@ -258,14 +258,14 @@ namespace Recore.Linq.Tests
 
             if (collection.Count == 0)
             {
-                Assert.Throws<InvalidOperationException>(() => collection.Max());
-                Assert.Throws<InvalidOperationException>(() => collection.Argmax());
+                Assert.Throws<InvalidOperationException>(() => collection.Min());
+                Assert.Throws<InvalidOperationException>(() => collection.Argmin());
             }
             else
             {
                 Assert.Equal(
-                    collection.Max(),
-                    collection.Argmax().Max);
+                    collection.Min(),
+                    collection.Argmin().Min);
             }
         }
 

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -141,7 +141,6 @@ namespace Recore.Linq.Tests
                 return;
             }
 
-
             if (collection.Count == 0)
             {
                 Assert.Null(collection.Min());
@@ -341,6 +340,248 @@ namespace Recore.Linq.Tests
                 Assert.Equal(
                     collection.Min(),
                     collection.Argmin().Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_Int32(List<int> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_NullableInt32(List<int?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_Int64(List<long> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_NullableInt64(List<long?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_Double(List<double> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_NullableDouble(List<double?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_Single(List<float> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_NullableSingle(List<float?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_Decimal(List<decimal> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_NullableDecimal(List<decimal?> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
+            }
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Selector_String(List<string> projected)
+        {
+            if (projected is null)
+            {
+                return;
+            }
+
+            var source = Enumerable.Range(0, projected.Count).ToList();
+            if (source.Count == 0)
+            {
+                Assert.Null(source.Min(x => projected[x]));
+                Assert.Throws<InvalidOperationException>(() => source.Argmin(x => projected[x]));
+            }
+            else
+            {
+                Assert.Equal(
+                    source.Min(x => projected[x]),
+                    source.Argmin(x => projected[x]).Min);
             }
         }
     }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -23,10 +23,23 @@ namespace Recore.Linq.Tests
         [Fact]
         public void EmptyEnumerable()
         {
-            // Nullable types return null
-            Assert.Null(Enumerable.Empty<string>().Argmin(x => x.GetHashCode()).Argmin);
+            // Non-nullable TSource throws
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<int>().Argmin().Argmin);
 
-            // Non-nullable types throw
+            // Nullable TSource returns 0
+            Assert.Equal(0, Enumerable.Empty<string>().Argmin().Argmin);
+
+            // Nullable TSource and TResult returns null
+            Assert.Null(Enumerable.Empty<string>().Argmin(x => x.ToUpper()).Argmin);
+
+            // When one or both of TSource and TResult is non-nullable, throws
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<string>().Argmin(x => x.Length).Argmin);
+
+            Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<int>().Argmin(x => string.Empty).Argmin);
+
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmin(x => x * x));
         }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -98,5 +98,148 @@ namespace Recore.Linq.Tests
             var (argmin, min) = xs.Argmin(x => x);
             Assert.Equal(argmin, min);
         }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Int32(List<int> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_NullableInt32(List<int?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Int64(List<long> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_NullableInt64(List<long?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Double(List<double> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_NullableDouble(List<double?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Single(List<float> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_NullableSingle(List<float?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_Decimal(List<decimal> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_NullableDecimal(List<decimal?> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
+
+        [Property]
+        public void MinAlwaysEqualsEnumerableMin_String(List<string> collection)
+        {
+            if (collection is null || collection.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Equal(
+                collection.Min(),
+                collection.Argmin().Min);
+        }
     }
 }


### PR DESCRIPTION
This changes the behavior of `Argmin()` and `Argmax()` to match `Min()` and `Max()` in most cases.
Specifically, it may change the result of `Argmin()` and `Argmax()` for empty sequences and for sequences containing `null` or `NaN`.
Furthermore, `Argmin()` and `Argmax()` may throw `InvalidOperationException` on empty sequences where they didn't before.
For more information, see the design notes.