### PR TITLE
Add type annotations for nullable references to the API

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -15,7 +15,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: '2.2.401' # required by Coverlet
+    version: '3.1.402'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet build --configuration Release

--- a/.azure/pipelines/docs.yml
+++ b/.azure/pipelines/docs.yml
@@ -9,7 +9,7 @@ steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: '2.2.401' # required by Coverlet
+      version: '3.1.402'
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - script: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.2.401' # required by Coverlet
+        dotnet-version: '3.1.402'
 
     - name: dotnet build
       run: dotnet build --configuration Release

--- a/src/InternalsVisibleTo.cs
+++ b/src/InternalsVisibleTo.cs
@@ -1,3 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleTo("Recore.Tests")]
+[assembly: InternalsVisibleTo("Recore.Tests")]

--- a/src/Recore.Collections.Generic/IDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IDictionaryExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Recore.Collections.Generic
 {
@@ -15,6 +16,7 @@ namespace Recore.Collections.Generic
         /// This is duplicated from <see cref="IReadOnlyDictionaryExtensions.GetValueOrDefault{TKey, TValue}(IReadOnlyDictionary{TKey, TValue}, TKey)"/>
         /// because <see cref="IDictionary{TKey, TValue}"/> does not extend <see cref="IReadOnlyDictionary{TKey, TValue}"/>.
         /// </remarks>
+        [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
         {
             if (dict.TryGetValue(key, out TValue value))
@@ -23,7 +25,7 @@ namespace Recore.Collections.Generic
             }
             else
             {
-                return default;
+                return default!;
             }
         }
 
@@ -35,6 +37,7 @@ namespace Recore.Collections.Generic
         /// in order to resolve the compile-time ambiguity between that method and <see cref="IReadOnlyDictionaryExtensions.GetValueOrDefault{TKey, TValue}(IReadOnlyDictionary{TKey, TValue}, TKey)"/>
         /// for instances of <see cref="Dictionary{TKey, TValue}"/>.
         /// </remarks>
+        [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
         {
             return dict.StaticCast<IDictionary<TKey, TValue>>().GetValueOrDefault(key);

--- a/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Recore.Collections.Generic
 {
@@ -11,6 +12,7 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Gets the value that is associated with the specific key or the default value for the type <typeparamref name="TValue"/>.
         /// </summary>
+        [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key)
         {
             if (dict.TryGetValue(key, out TValue value))
@@ -19,7 +21,7 @@ namespace Recore.Collections.Generic
             }
             else
             {
-                return default;
+                return default!;
             }
         }
 
@@ -31,6 +33,7 @@ namespace Recore.Collections.Generic
         /// in order to resolve the compile-time ambiguity between that method and <see cref="IDictionaryExtensions.GetValueOrDefault{TKey, TValue}(IDictionary{TKey, TValue}, TKey)"/>
         /// for instances of <see cref="ReadOnlyDictionary{TKey, TValue}"/>.
         /// </remarks>
+        [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this ReadOnlyDictionary<TKey, TValue> dict, TKey key)
         {
             return dict.StaticCast<IReadOnlyDictionary<TKey, TValue>>().GetValueOrDefault(key);

--- a/src/Recore.Collections.Generic/Iterator.cs
+++ b/src/Recore.Collections.Generic/Iterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Recore.Collections.Generic
 {
@@ -57,6 +58,8 @@ namespace Recore.Collections.Generic
         public bool HasNext { get; private set; }
 
         private readonly IEnumerator<T> enumerator;
+
+        // After the constructor runs, these are null if and only if the collection is empty
         private T current;
         private T lookahead;
 
@@ -71,6 +74,12 @@ namespace Recore.Collections.Generic
             {
                 current = enumerator.Current; // appease the compiler; will get discarded on the first call to `Next()`
                 lookahead = enumerator.Current;
+            }
+            else
+            {
+                // Appease the compiler
+                // These will not be dereferenced
+                current = lookahead = default!;
             }
         }
 

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-// TODO https://github.com/recorefx/RecoreFX/issues/24
-//using System.Diagnostics.CodeAnalysis;
 
 using Recore.Properties;
 
@@ -518,8 +516,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the index of the maximum value from a sequence of values.
         /// </summary>
-        // TODO https://github.com/recorefx/RecoreFX/issues/24
-        //[return: MaybeNull]
+        // TODO C# 9.0: this should be TSource? Max
         public static (int Argmax, TSource Max) Argmax<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
@@ -528,8 +525,6 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            // TODO https://github.com/recorefx/RecoreFX/issues/24
-            //TSource value = default!;
             (int Index, TSource Item) value = (0, default);
             if (value.Item == null)
             {
@@ -1182,8 +1177,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function on a sequence of values.
         /// </summary>
-        // TODO https://github.com/recorefx/RecoreFX/issues/24
-        //[return: MaybeNull]
+        // TODO C# 9.0: this should be (TSource? Argmax, TResult? Max)
         public static (TSource Argmax, TResult Max) Argmax<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
             if (source is null)
@@ -1197,8 +1191,6 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            // TODO https://github.com/recorefx/RecoreFX/issues/24
-            //TResult value = default!;
             TSource argmaxCandidate = default;
             TResult value = default;
             if (value == null)

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 using Recore.Properties;
 

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
-// TODO https://github.com/recorefx/RecoreFX/issues/24
-//using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using Recore.Properties;
 
@@ -475,8 +474,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the index of the minimum value from a sequence of values.
         /// </summary>
-        // TODO https://github.com/recorefx/RecoreFX/issues/24
-        //[return: MaybeNull]
+        // TODO C# 9.0: this should be TSource? Min
         public static (int Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
@@ -485,8 +483,6 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            // TODO https://github.com/recorefx/RecoreFX/issues/24
-            //TSource value = default!;
             (int Index, TSource Item) value = (0, default);
             if (value.Item == null)
             {
@@ -1092,8 +1088,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function on a sequence of values.
         /// </summary>
-        // TODO https://github.com/recorefx/RecoreFX/issues/24
-        //[return: MaybeNull]
+        // TODO C# 9.0: this should be (TSource? Argmin, TResult? Min)
         public static (TSource Argmin, TResult Min) Argmin<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
             if (source is null)
@@ -1107,8 +1102,6 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            // TODO https://github.com/recorefx/RecoreFX/issues/24
-            //TResult value = default!;
             TSource argminCandidate = default;
             TResult value = default;
             if (value == null)

--- a/src/Recore.Linq/NonNull.cs
+++ b/src/Recore.Linq/NonNull.cs
@@ -8,10 +8,11 @@ namespace Recore.Linq
         /// <summary>
         /// Collects all non-null values from the sequence.
         /// </summary>
-        public static IEnumerable<TSource> NonNull<TSource>(this IEnumerable<TSource> source)
+        public static IEnumerable<TSource> NonNull<TSource>(this IEnumerable<TSource?> source)
         where TSource : class
             => source
-            .Where(x => x != null);
+                .Where(x => x != null)
+                .Select(x => x!);
 
         /// <summary>
         /// Collects all non-null values from the sequence.
@@ -19,7 +20,7 @@ namespace Recore.Linq
         public static IEnumerable<TSource> NonNull<TSource>(this IEnumerable<TSource?> source)
         where TSource : struct
             => source
-            .Where(x => x != null)
-            .Select(x => x.Value);
+                .Where(x => x != null)
+                .Select(x => x!.Value);
     }
 }

--- a/src/Recore.Text.Json.Serialization.Converters/OptionalConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/OptionalConverter.cs
@@ -27,7 +27,7 @@ namespace Recore.Text.Json.Serialization.Converters
     /// JSON converter for the generic type <seealso cref="Optional{T}"/>
     /// for a given <typeparamref name="T"/>.
     /// </summary>
-    internal sealed class OptionalConverter<T> : JsonConverter<Optional<T>>
+    internal sealed class OptionalConverter<T> : JsonConverter<Optional<T>> where T : notnull
     {
         public override Optional<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/Recore.Text.Json.Serialization.Converters/UriConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/UriConverter.cs
@@ -11,7 +11,7 @@ namespace Recore.Text.Json.Serialization.Converters
         public override AbsoluteUri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             string uriString = reader.GetString();
-            if (AbsoluteUri.TryCreate(uriString, out AbsoluteUri value))
+            if (AbsoluteUri.TryCreate(uriString, out AbsoluteUri? value))
             {
                 return value;
             }
@@ -30,7 +30,7 @@ namespace Recore.Text.Json.Serialization.Converters
         public override RelativeUri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             string uriString = reader.GetString();
-            if (RelativeUri.TryCreate(uriString, out RelativeUri value))
+            if (RelativeUri.TryCreate(uriString, out RelativeUri? value))
             {
                 return value;
             }

--- a/src/Recore.csproj
+++ b/src/Recore.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>Recore</RootNamespace>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -19,6 +19,7 @@
     <Product>RecoreFX</Product>
     <Copyright>Copyright (c) 2019 Brian Cristante</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Recore.csproj
+++ b/src/Recore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Recore</RootNamespace>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -75,7 +75,7 @@ namespace Recore
         public Either(TLeft left)
         {
             this.left = left;
-            right = default;
+            right = default!;
             IsLeft = true;
         }
 
@@ -199,8 +199,8 @@ namespace Recore
         /// </summary>
         public override string ToString()
             => Switch(
-                l => l.ToString(),
-                r => r.ToString());
+                l => l!.ToString(),
+                r => r!.ToString());
 
         /// <summary>
         /// Compares this <see cref="Either{TLeft, TRight}"/>
@@ -226,7 +226,7 @@ namespace Recore
         /// even if <c>Color.Red == Day.Monday</c>.
         /// </remarks>
         public bool Equals(Either<TLeft, TRight> other)
-            => other != null
+            => !(other is null)
             && Switch(
                 l => other.Switch(
                     otherLeft => Equals(l, otherLeft),
@@ -240,8 +240,8 @@ namespace Recore
         /// </summary>
         public override int GetHashCode()
             => Switch(
-                l => l.GetHashCode(),
-                r => r.GetHashCode());
+                l => l!.GetHashCode(),
+                r => r!.GetHashCode());
 
         /// <summary>
         /// Determines whether two instances of <see cref="Either{TLeft, TRight}"/>

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -84,7 +84,7 @@ namespace Recore
         /// </summary>
         public Either(TRight right)
         {
-            left = default;
+            left = default!;
             this.right = right;
             IsLeft = false;
         }

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -138,22 +138,6 @@ namespace Recore
         }
 
         /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TLeft&gt;</c>.
-        /// </summary>
-        public Optional<TLeft> GetLeft()
-            => Switch(
-                Optional.Of,
-                r => Optional<TLeft>.Empty);
-
-        /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TRight&gt;</c>.
-        /// </summary>
-        public Optional<TRight> GetRight()
-            => Switch(
-                l => Optional<TRight>.Empty,
-                Optional.Of);
-
-        /// <summary>
         /// Maps a function over the <see cref="Either{TLeft, TRight}"/> only if the value is an instance of <typeparamref name="TLeft"/>.
         /// </summary>
         public Either<TResult, TRight> OnLeft<TResult>(Func<TLeft, TResult> onLeft)
@@ -272,6 +256,38 @@ namespace Recore
     public static class Either
     {
         /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <see cref="Optional{T}">Optional&lt;TLeft&gt;</see>.
+        /// </summary>
+        public static Optional<TLeft> GetLeft<TLeft, TRight>(this Either<TLeft, TRight> either) where TLeft : notnull
+            => either.Switch(
+                Optional.Of,
+                r => Optional<TLeft>.Empty);
+
+        /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}">Either&lt;Nullable&lt;TLeft&gt;, TRight&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TLeft&gt;</see>.
+        /// </summary>
+        public static TLeft? GetLeft<TLeft, TRight>(this Either<TLeft?, TRight> either) where TLeft : struct
+            => either.Switch(
+                l => l,
+                r => null);
+
+        /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TRight&gt;</c>.
+        /// </summary>
+        public static Optional<TRight> GetRight<TLeft, TRight>(this Either<TLeft, TRight> either) where TRight : notnull
+            => either.Switch(
+                l => Optional<TRight>.Empty,
+                Optional.Of);
+
+        /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}">Either&lt;TLeft, Nullable&lt;TRight&gt;&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TRight&gt;</see>.
+        /// </summary>
+        public static TRight? GetRight<TLeft, TRight>(this Either<TLeft, TRight?> either) where TRight : struct
+            => either.Switch(
+                l => null,
+                r => r);
+
+        /// <summary>
         /// Retrieves the value of an <see cref="Either{TLeft, TRight}"/> when <c>TLeft</c> and <c>TRight</c> are the same.
         /// </summary>
         public static T Collapse<T>(this Either<T, T> either)
@@ -323,15 +339,19 @@ namespace Recore
         /// </summary>
         public static IEnumerable<TLeft> Lefts<TLeft, TRight>(this IEnumerable<Either<TLeft, TRight>> source)
             => source
-            .Select(x => x.GetLeft())
-            .NonEmpty();
+                .Where(x => x.IsLeft)
+                .Select(x => x.Switch(
+                    l => l,
+                    r => throw new InvalidOperationException()));
 
         /// <summary>
         /// Collects all the right-side values from the sequence.
         /// </summary>
         public static IEnumerable<TRight> Rights<TLeft, TRight>(this IEnumerable<Either<TLeft, TRight>> source)
             => source
-            .Select(x => x.GetRight())
-            .NonEmpty();
+                .Where(x => x.IsRight)
+                .Select(x => x.Switch(
+                    l => throw new InvalidOperationException(),
+                    r => r));
     }
 }

--- a/src/Recore/Func.cs
+++ b/src/Recore/Func.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Recore
 {

--- a/src/Recore/Of.cs
+++ b/src/Recore/Of.cs
@@ -34,7 +34,7 @@ namespace Recore
         /// <summary>
         /// The underlying instance of the wrapped type.
         /// </summary>
-        public T Value { get; set; }
+        public T Value { get; set; } = default!;
 
         /// <summary>
         /// Converts this <see cref="Of{T}"/> to another subtype of <see cref="Of{T}"/>
@@ -46,7 +46,7 @@ namespace Recore
         /// <summary>
         /// Returns the string representation for the underlying object.
         /// </summary>
-        public override string ToString() => Value.ToString();
+        public override string ToString() => Value!.ToString();
 
         /// <summary>
         /// Determines whether this instance is equal to another object.
@@ -62,13 +62,13 @@ namespace Recore
         /// will compare equal to each other if their values are the same type and are equal.
         /// </remarks>
         public bool Equals(Of<T> other)
-            => other != null
+            => !(other is null)
             && Equals(Value, other.Value);
 
         /// <summary>
         /// Returns the hash code for the underlying object.
         /// </summary>
-        public override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value!.GetHashCode();
 
         /// <summary>
         /// Determines whether two instances of the type are equal.

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -175,7 +175,7 @@ namespace Recore
         /// </summary>
         public override string ToString()
             => Switch(
-                x => x.ToString(),
+                x => x!.ToString(),
                 () => Resources.OptionalEmptyToString);
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Recore
         /// </summary>
         public override int GetHashCode()
             => Switch(
-                x => x.GetHashCode(),
+                x => x!.GetHashCode(),
                 () => 0);
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Recore
         /// or the default value for the underlying type.
         /// </summary>
         public static explicit operator T(Optional<T> optional)
-            => optional.ValueOr(default);
+            => optional.ValueOr(default!);
     }
 
     /// <summary>

--- a/src/Recore/Result.cs
+++ b/src/Recore/Result.cs
@@ -174,7 +174,7 @@ namespace Recore
         /// Equality is defined as both objects' underlying values or errors being equal.
         /// </remarks>
         public bool Equals(Result<TValue, TError> other)
-            => other != null
+            => !(other is null)
             && this.either == other.either;
 
         /// <summary>

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -74,7 +74,7 @@ namespace Recore
         /// </remarks>
         public static Token[] Tokenize(this string str)
         {
-            var parts = str.Split(separator: (char[])null, StringSplitOptions.RemoveEmptyEntries);
+            var parts = str.Split(separator: (char[]?)null, StringSplitOptions.RemoveEmptyEntries);
             var tokens = new Token[parts.Length];
 
             for (int i = 0; i < parts.Length; i++)

--- a/src/Recore/Uri.cs
+++ b/src/Recore/Uri.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 using Recore.Text.Json.Serialization.Converters;
@@ -31,12 +32,12 @@ namespace Recore
         /// <summary>
         /// Creates a new <see cref="AbsoluteUri"/>. Does not throw an exception if the <see cref="AbsoluteUri"/> cannot be created.
         /// </summary>
-        public static bool TryCreate(string uriString, out AbsoluteUri result)
+        public static bool TryCreate(string uriString, [NotNullWhen(true)] out AbsoluteUri? result)
         {
             result = null;
             if (TryCreate(uriString, UriKind.Absolute, out Uri value))
             {
-                result = value.AsAbsoluteUri();
+                result = value.AsAbsoluteUri()!;
                 return true;
             }
             else
@@ -60,12 +61,12 @@ namespace Recore
         /// <summary>
         /// Creates a new <see cref="RelativeUri"/>. Does not throw an exception if the <see cref="RelativeUri"/> cannot be created.
         /// </summary>
-        public static bool TryCreate(string uriString, out RelativeUri result)
+        public static bool TryCreate(string uriString, [NotNullWhen(true)] out RelativeUri? result)
         {
             result = null;
             if (TryCreate(uriString, UriKind.Relative, out Uri value))
             {
-                result = value.AsRelativeUri();
+                result = value.AsRelativeUri()!;
                 return true;
             }
             else
@@ -90,7 +91,7 @@ namespace Recore
         /// <see cref="AsAbsoluteUri(Uri)"/> works as <c>uri as AbsoluteUri</c> would if <see cref="Uri"/> were an abstract base class.
         /// It complements <see cref="Uri.IsAbsoluteUri"/> in this regard.
         /// </remarks>
-        public static AbsoluteUri AsAbsoluteUri(this Uri uri)
+        public static AbsoluteUri? AsAbsoluteUri(this Uri uri)
         {
             if (uri.IsAbsoluteUri)
             {
@@ -111,7 +112,7 @@ namespace Recore
         /// patterns like <c>(AbsoluteUri)uri</c> or <c>uri as AbsoluteUri</c> cannot be used reliably.
         /// <see cref="AsRelativeUri(Uri)"/> works as <c>uri as RelativeUri</c> would if <see cref="Uri"/> were an abstract base class.
         /// </remarks>
-        public static RelativeUri AsRelativeUri(this Uri uri)
+        public static RelativeUri? AsRelativeUri(this Uri uri)
         {
             if (uri.IsAbsoluteUri)
             {

--- a/test/Recore.Collections.Generic/AnonymousEqualityComparerTests.cs
+++ b/test/Recore.Collections.Generic/AnonymousEqualityComparerTests.cs
@@ -10,7 +10,7 @@ namespace Recore.Tests.Recore.Collections.Generic
         private class Person
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
             public int Age { get; set; }
         }
 

--- a/test/Recore.Collections.Generic/ICollectionExtensionsTests.cs
+++ b/test/Recore.Collections.Generic/ICollectionExtensionsTests.cs
@@ -12,19 +12,19 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                ICollection<string> collection = null;
-                collection.Append("hello");
+                ICollection<string>? collection = null;
+                collection!.Append("hello");
             });
         }
 
         [Fact]
         public void Append_EmptyCollection()
         {
-            var collection = new List<string>()
+            var collection = new List<string?>()
                 .Append(null)
                 .Append("hello");
 
-            var expected = new List<string>
+            var expected = new List<string?>
             {
                 null,
                 "hello"

--- a/test/Recore.Collections.Generic/IDictionaryExtensionsTests.cs
+++ b/test/Recore.Collections.Generic/IDictionaryExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                IDictionary<string, int> dictionary = null;
+                IDictionary<string, int> dictionary = null!;
                 dictionary.GetValueOrDefault("hello");
             });
         }
@@ -44,7 +44,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                IDictionary<string, int> dictionary = null;
+                IDictionary<string, int> dictionary = null!;
                 dictionary.Append("hello", 1);
             });
         }
@@ -96,7 +96,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                IDictionary<string, int> dictionary = null;
+                IDictionary<string, int> dictionary = null!;
                 dictionary.GetOrAdd("hello", 1);
             });
         }
@@ -128,7 +128,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                IDictionary<string, int> dictionary = null;
+                IDictionary<string, int> dictionary = null!;
                 dictionary.AddRange(new Dictionary<string, int> { ["hello"] = 1 });
             });
         }
@@ -136,8 +136,8 @@ namespace Recore.Collections.Generic.Tests
         [Fact]
         public void AddRange_EmptyDictionary()
         {
-            var dictionary = new Dictionary<string, string>();
-            var otherDictionary = new Dictionary<string, string>
+            var dictionary = new Dictionary<string, string?>();
+            var otherDictionary = new Dictionary<string, string?>
             {
                 ["abc"] = null,
                 ["hello"] = "world"

--- a/test/Recore.Collections.Generic/IDictionaryExtensionsTests.cs
+++ b/test/Recore.Collections.Generic/IDictionaryExtensionsTests.cs
@@ -52,11 +52,11 @@ namespace Recore.Collections.Generic.Tests
         [Fact]
         public void Append_EmptyDictionary()
         {
-            var dictionary = new Dictionary<string, string>()
+            var dictionary = new Dictionary<string, string?>()
                 .Append("abc", null)
                 .Append("hello", "world");
 
-            var expected = new Dictionary<string, string>
+            var expected = new Dictionary<string, string?>
             {
                 ["abc"] = null,
                 ["hello"] = "world"

--- a/test/Recore.Collections.Generic/LinkedListExtensionsTests.cs
+++ b/test/Recore.Collections.Generic/LinkedListExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                LinkedList<string> list = null;
+                LinkedList<string> list = null!;
                 list.Append("hello");
             });
         }
@@ -20,11 +20,11 @@ namespace Recore.Collections.Generic.Tests
         [Fact]
         public void Append_EmptyList()
         {
-            var list = new LinkedList<string>()
+            var list = new LinkedList<string?>()
                 .Append(null)
                 .Append("hello");
 
-            var expected = new LinkedList<string>
+            var expected = new LinkedList<string?>
             {
                 null,
                 "hello"

--- a/test/Recore.Collections.Generic/ListExtensionsTests.cs
+++ b/test/Recore.Collections.Generic/ListExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Recore.Collections.Generic.Tests
         {
             Assert.Throws<NullReferenceException>(() =>
             {
-                List<string> list = null;
+                List<string> list = null!;
                 list.AppendRange(new[] { "hello" });
             });
         }
@@ -22,7 +22,7 @@ namespace Recore.Collections.Generic.Tests
         public void AppendRange_NullArgument()
         {
             Assert.Throws<ArgumentNullException>(
-                () => new List<string>().AppendRange(null));
+                () => new List<string>().AppendRange(null!));
         }
 
         [Fact]

--- a/test/Recore.Collections.Generic/MappedComparerTests.cs
+++ b/test/Recore.Collections.Generic/MappedComparerTests.cs
@@ -10,7 +10,7 @@ namespace Recore.Tests.Recore.Collections.Generic
         private class Person
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
             public int Age { get; set; }
         }
 

--- a/test/Recore.Collections.Generic/MappedEqualityComparerTests.cs
+++ b/test/Recore.Collections.Generic/MappedEqualityComparerTests.cs
@@ -9,7 +9,7 @@ namespace Recore.Tests.Recore.Collections.Generic
         private class Person
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
             public int Age { get; set; }
         }
 

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -76,7 +76,17 @@ namespace Recore.Linq.Tests
         }
 
         [Fact]
-        public void ArgmaxObject()
+        public void ArgmaxInt32()
+        {
+            var collection = new[] { 1, 3, 4, 1 };
+
+            Assert.Equal(
+                (Argmax: 4, Max: 4),
+                collection.Argmax(x => x));
+        }
+
+        [Fact]
+        public void ArgmaxGeneric()
         {
             var collection = new[]
             {
@@ -91,13 +101,32 @@ namespace Recore.Linq.Tests
         }
 
         [Fact]
-        public void ArgmaxInt32()
+        public void ArgmaxGenericWithNull()
         {
-            var collection = new[] { 1, 3, 4, 1 };
+            var collection = new[]
+            {
+                "abc",
+                null,
+                "hello world"
+            };
 
             Assert.Equal(
-                (Argmax: 4, Max: 4),
-                collection.Argmax(x => x));
+                (Argmax: collection[2], Max: 11),
+                collection.Argmax(x => x?.Length));
+        }
+
+        [Fact]
+        public void ArgmaxGenericAllNull()
+        {
+            var collection = new string?[]
+            {
+                null,
+                null
+            };
+
+            Assert.Equal(
+                (Argmax: null, Max: null),
+                collection.Argmax(x => x?.Length));
         }
 
         [Property]

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -129,6 +129,17 @@ namespace Recore.Linq.Tests
                 collection.Argmax(x => x?.Length));
         }
 
+        [Fact]
+        public void ArgmaxGenericNRE()
+        {
+            var collection = new string[]
+            {
+            };
+
+            var argmax = collection.Argmax(x => x?.Length).Argmax;
+            Assert.Throws<NullReferenceException>(() => argmax.Length);
+        }
+
         [Property]
         public void ArgmaxEqualsMaxForIdentityFunction(List<int> xs)
         {

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -14,10 +14,10 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.Argmax<object, int>(null, x => x.GetHashCode()));
+                () => Renumerable.Argmax<object, int>(null!, x => x.GetHashCode()));
 
             Assert.Throws<ArgumentNullException>(
-                () => new[] { 0 }.Argmax<int, int>(null));
+                () => new[] { 0 }.Argmax<int, int>(null!));
         }
 
         [Fact]

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -76,7 +76,17 @@ namespace Recore.Linq.Tests
         }
 
         [Fact]
-        public void ArgminObject()
+        public void ArgminInt32()
+        {
+            var collection = new[] { 1, 3, 4, 1 };
+
+            Assert.Equal(
+                (Argmin: 1, Min: 1),
+                collection.Argmin(x => x));
+        }
+
+        [Fact]
+        public void ArgminGeneric()
         {
             var collection = new[]
             {
@@ -91,13 +101,32 @@ namespace Recore.Linq.Tests
         }
 
         [Fact]
-        public void ArgminInt32()
+        public void ArgmaxGenericWithNull()
         {
-            var collection = new[] { 1, 3, 4, 1 };
+            var collection = new[]
+            {
+                "abc",
+                null,
+                "hello world"
+            };
 
             Assert.Equal(
-                (Argmin: 1, Min: 1),
-                collection.Argmin(x => x));
+                (Argmin: collection[0], Min: 3),
+                collection.Argmin(x => x?.Length));
+        }
+
+        [Fact]
+        public void ArgminGenericAllNull()
+        {
+            var collection = new string?[]
+            {
+                null,
+                null
+            };
+
+            Assert.Equal(
+                (Argmin: null, Min: null),
+                collection.Argmin(x => x?.Length));
         }
 
         [Property]

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -129,6 +129,17 @@ namespace Recore.Linq.Tests
                 collection.Argmin(x => x?.Length));
         }
 
+        [Fact]
+        public void ArgminGenericNRE()
+        {
+            var collection = new string[]
+            {
+            };
+
+            var argmin = collection.Argmin(x => x?.Length).Argmin;
+            Assert.Throws<NullReferenceException>(() => argmin.Length);
+        }
+
         [Property]
         public void ArgminEqualsMinForIdentityFunction(List<int> xs)
         {

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -14,10 +14,10 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.Argmin<object, int>(null, x => x.GetHashCode()));
+                () => Renumerable.Argmin<object, int>(null!, x => x.GetHashCode()));
 
             Assert.Throws<ArgumentNullException>(
-                () => new[] { 0 }.Argmin<int, int>(null));
+                () => new[] { 0 }.Argmin<int, int>(null!));
         }
 
         [Fact]

--- a/test/Recore.Linq/EnumerateTests.cs
+++ b/test/Recore.Linq/EnumerateTests.cs
@@ -13,7 +13,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ThrowsOnNull()
         {
-            IEnumerable<object> nullEnumerable = null;
+            IEnumerable<object> nullEnumerable = null!;
             Assert.Throws<ArgumentNullException>(
                 () => TestHelpers.ForceExecution(nullEnumerable.Enumerate));
         }
@@ -28,9 +28,9 @@ namespace Recore.Linq.Tests
         [Fact]
         public void NullElement()
         {
-            var enumerable = new string[] { null };
+            var enumerable = new string?[] { null };
 
-            var expected = new (int, string)[]
+            var expected = new (int, string?)[]
             {
                 (0, null)
             };

--- a/test/Recore.Linq/FlattenTests.cs
+++ b/test/Recore.Linq/FlattenTests.cs
@@ -11,7 +11,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ThrowsOnNull()
         {
-            IEnumerable<IEnumerable<object>> nullEnumerable = null;
+            IEnumerable<IEnumerable<object>> nullEnumerable = null!;
             Assert.Throws<ArgumentNullException>(
                 () => nullEnumerable.Flatten());
         }

--- a/test/Recore.Linq/ForEachTests.cs
+++ b/test/Recore.Linq/ForEachTests.cs
@@ -12,10 +12,10 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.ForEach<object>(null, x => { }));
+                () => Renumerable.ForEach<object>(null!, x => { }));
 
             Assert.Throws<ArgumentNullException>(
-                () => Enumerable.Empty<object>().ForEach(null));
+                () => Enumerable.Empty<object>().ForEach(null!));
         }
 
         [Fact]

--- a/test/Recore.Linq/KeyValuePairTests.cs
+++ b/test/Recore.Linq/KeyValuePairTests.cs
@@ -12,19 +12,19 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.ToDictionary<string, int>(null));
+                () => Renumerable.ToDictionary<string, int>(null!));
 
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.OnKeys<string, int, int>(null, x => 1));
+                () => Renumerable.OnKeys<string, int, int>(null!, x => 1));
 
             Assert.Throws<ArgumentNullException>(
-                () => Enumerable.Empty<KeyValuePair<string, int>>().OnKeys<string, int, int>(null));
+                () => Enumerable.Empty<KeyValuePair<string, int>>().OnKeys<string, int, int>(null!));
 
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.OnValues<string, int, int>(null, x => 1));
+                () => Renumerable.OnValues<string, int, int>(null!, x => 1));
 
             Assert.Throws<ArgumentNullException>(
-                () => Enumerable.Empty<KeyValuePair<string, int>>().OnValues<string, int, int>(null));
+                () => Enumerable.Empty<KeyValuePair<string, int>>().OnValues<string, int, int>(null!));
         }
 
         [Fact]

--- a/test/Recore.Linq/LiftTests.cs
+++ b/test/Recore.Linq/LiftTests.cs
@@ -12,7 +12,7 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.Lift<object>(null));
+                () => Renumerable.Lift<object>(null!));
         }
 
         [Fact]

--- a/test/Recore.Linq/NonNullTests.cs
+++ b/test/Recore.Linq/NonNullTests.cs
@@ -11,7 +11,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ThrowsOnNull()
         {
-            IEnumerable<object> nullEnumerable = null;
+            IEnumerable<object> nullEnumerable = null!;
             Assert.Throws<ArgumentNullException>(() => nullEnumerable.NonNull());
         }
 

--- a/test/Recore.Linq/ProductTests.cs
+++ b/test/Recore.Linq/ProductTests.cs
@@ -13,7 +13,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ThrowsOnNull()
         {
-            IEnumerable<object> nullEnumerable = null;
+            IEnumerable<object> nullEnumerable = null!;
             Assert.Throws<ArgumentNullException>(
                 () => TestHelpers.ForceExecution(() => nullEnumerable.Product(new[] { 0 })));
 

--- a/test/Recore.Linq/ToLinkedListTests.cs
+++ b/test/Recore.Linq/ToLinkedListTests.cs
@@ -13,7 +13,7 @@ namespace Recore.Linq.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Renumerable.ToLinkedList<object>(null));
+                () => Renumerable.ToLinkedList<object>(null!));
         }
 
         [Fact]

--- a/test/Recore.Security.Cryptography/CiphertextTests.cs
+++ b/test/Recore.Security.Cryptography/CiphertextTests.cs
@@ -15,13 +15,13 @@ namespace Recore.Security.Cryptography.Tests
             using (var sha256 = SHA256.Create())
             {
                 Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt(null, Array.Empty<byte>(), sha256));
+                    () => Ciphertext<SHA256>.Encrypt(null!, Array.Empty<byte>(), sha256));
 
                 Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt("hello", null, sha256));
+                    () => Ciphertext<SHA256>.Encrypt("hello", null!, sha256));
 
                 Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt("hello", Array.Empty<byte>(), null));
+                    () => Ciphertext<SHA256>.Encrypt("hello", Array.Empty<byte>(), null!));
             }
         }
 

--- a/test/Recore.Security.Cryptography/SecureCompareTests.cs
+++ b/test/Recore.Security.Cryptography/SecureCompareTests.cs
@@ -13,10 +13,10 @@ namespace Recore.Security.Cryptography.Tests
         public void ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => SecureCompare.TimeInvariantEquals(null, new byte[] { }));
+                () => SecureCompare.TimeInvariantEquals(null!, new byte[] { }));
 
             Assert.Throws<ArgumentNullException>(
-                () => SecureCompare.TimeInvariantEquals(new byte[] { }, null));
+                () => SecureCompare.TimeInvariantEquals(new byte[] { }, null!));
         }
 
         [Fact]

--- a/test/Recore.Tests.csproj
+++ b/test/Recore.Tests.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Recore.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Recore.Tests.csproj
+++ b/test/Recore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Recore.Tests</RootNamespace>
   </PropertyGroup>

--- a/test/Recore.Text.Json.Serialization.Converters/EitherConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/EitherConverterTests.cs
@@ -87,7 +87,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
             var deserializedPerson = JsonSerializer.Deserialize<Either<Person, string>>("{\"Name\":\"Mario\",\"Age\":42}");
             Assert.Equal(
                 expected: "Mario",
-                actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
+                actual: deserializedPerson!.GetLeft().OnValue(x => x.Name));
 
             Assert.Equal(
                 expected: 42,

--- a/test/Recore.Text.Json.Serialization.Converters/Internal/Types.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/Internal/Types.cs
@@ -8,14 +8,14 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
 
     class Person
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
         public int Age { get; set; }
     }
 
     class Address
     {
-        public string Street { get; set; }
-        public string Zip { get; set; }
+        public string? Street { get; set; }
+        public string? Zip { get; set; }
     }
 
     [JsonConverter(typeof(TypeWithConverterConverter))]
@@ -23,7 +23,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
     {
         public int Age { get; set; }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         public string GetFullName() => $"{Name} {Name}son";
     }

--- a/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
@@ -27,7 +27,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
 
         class House
         {
-            public JsonStreetAddress Street { get; set; }
+            public JsonStreetAddress? Street { get; set; }
         }
 
         [OfJson(typeof(User), typeof(Person))]

--- a/test/Recore.Text.Json.Serialization.Converters/ResultConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/ResultConverterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text.Json;
 using Xunit;
 

--- a/test/Recore/ComposerTests.cs
+++ b/test/Recore/ComposerTests.cs
@@ -7,8 +7,7 @@ namespace Recore.Functional.Tests
         [Fact]
         public void TrivialComposer()
         {
-            // TODO .NET Core 3
-            /*static*/ bool IsEven(int x) => x % 2 == 0;
+            static bool IsEven(int x) => x % 2 == 0;
             var func = new Composer<int, bool>(IsEven)
                 .Func;
 
@@ -24,7 +23,7 @@ namespace Recore.Functional.Tests
                 .Then(x => x.Length)
                 .Func;
 
-            Assert.Equal(4, func(null));
+            Assert.Equal(4, func(null!));
             Assert.Equal(4, func(string.Empty));
             Assert.Equal(5, func("hello"));
         }

--- a/test/Recore/EitherTests.cs
+++ b/test/Recore/EitherTests.cs
@@ -52,11 +52,11 @@ namespace Recore.Tests
             Assert.Throws<ArgumentNullException>(
                 () => either.Switch(
                     l => throw new Exception("Should not be called"),
-                    null));
+                    null!));
 
             Assert.Throws<ArgumentNullException>(
                 () => either.Switch(
-                    null,
+                    null!,
                     r => throw new Exception("Should not be called")));
         }
 
@@ -83,11 +83,11 @@ namespace Recore.Tests
             Assert.Throws<ArgumentNullException>(
                 () => either.Switch(
                     l => throw new Exception("Should not be called"),
-                    null));
+                    null!));
 
             Assert.Throws<ArgumentNullException>(
                 () => either.Switch(
-                    null,
+                    null!,
                     r => throw new Exception("Should not be called")));
         }
 
@@ -160,7 +160,7 @@ namespace Recore.Tests
         public void EqualsWithNull()
         {
             Assert.False(
-                new Either<int, string>("abc").Equals(null));
+                new Either<int, string>("abc").Equals(null!));
         }
 
         [Theory]
@@ -317,16 +317,16 @@ namespace Recore.Tests
         public void Lift_ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int>(null, x => { }));
+                () => Either.Lift<string, int>(null!, x => { }));
 
             Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int>(x => { }, null));
+                () => Either.Lift<string, int>(x => { }, null!));
 
             Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int, int>(null, x => 1));
+                () => Either.Lift<string, int, int>(null!, x => 1));
 
             Assert.Throws<ArgumentNullException>(
-                () => Either.Lift<string, int, int>(x => 1, null));
+                () => Either.Lift<string, int, int>(x => 1, null!));
         }
 
         [Fact]

--- a/test/Recore/EitherTests.cs
+++ b/test/Recore/EitherTests.cs
@@ -92,18 +92,6 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void GetLeftGetRight()
-        {
-            var left = new Either<int, string>(-5);
-            Assert.Equal(-5, left.GetLeft());
-            Assert.False(left.GetRight().HasValue);
-
-            var right = new Either<int, string>("hello");
-            Assert.False(right.GetLeft().HasValue);
-            Assert.Equal("hello", right.GetRight());
-        }
-
-        [Fact]
         public void OnLeftOnRight()
         {
             Either<int, string> either;
@@ -295,6 +283,34 @@ namespace Recore.Tests
                     day => Equals((int)color, (int)day),
                     str => false),
                 str => false));
+        }
+
+        [Fact]
+        public void GetLeftGetRight()
+        {
+            var left = new Either<int, string>(-5);
+            Assert.Equal(-5, left.GetLeft());
+            Assert.False(left.GetRight().HasValue);
+
+            var right = new Either<int, string>("hello");
+            Assert.False(right.GetLeft().HasValue);
+            Assert.Equal("hello", right.GetRight());
+        }
+
+        [Fact]
+        public void GetLeftGetRightNullable()
+        {
+            var left = new Either<int?, string>(-5);
+            Assert.Equal(-5, left.GetLeft());
+            Assert.False(left.GetRight().HasValue);
+
+            left = new Either<int?, string>(left: null);
+            Assert.Null(left.GetLeft());
+            Assert.False(left.GetRight().HasValue);
+
+            var right = new Either<int?, string>("hello");
+            Assert.Null(right.GetLeft());
+            Assert.Equal("hello", right.GetRight());
         }
 
         [Fact]

--- a/test/Recore/FuncTests.cs
+++ b/test/Recore/FuncTests.cs
@@ -7,7 +7,7 @@ namespace Recore.Tests
         [Fact]
         public void Invoke()
         {
-            string name = null;
+            string? name = null;
             var result = Func.Invoke(() =>
             {
                 if (name is null)

--- a/test/Recore/OfTests.cs
+++ b/test/Recore/OfTests.cs
@@ -24,7 +24,7 @@ namespace Recore.Tests
         public void EqualsWithNull()
         {
             var address1 = new Address("1 Microsoft Way");
-            Address address2 = null;
+            Address? address2 = null;
 
             Assert.NotEqual(address1, address2);
         }

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -113,7 +113,7 @@ namespace Recore.Tests
             optional = "hello world";
             Assert.Equal("hello world", optional.ValueOr("xxx"));
 
-            optional = null;
+            optional = null!;
             Assert.Equal("xxx", optional.ValueOr("xxx"));
         }
 
@@ -135,7 +135,7 @@ namespace Recore.Tests
             optional = "hello world";
             Assert.Equal("hello world", optional.AssertValue());
 
-            optional = null;
+            optional = null!;
             Assert.Throws<InvalidOperationException>(() => optional.AssertValue());
         }
 

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -18,7 +18,10 @@ namespace Recore.Tests
             var valueOptional = new Optional<int>(123);
             Assert.True(valueOptional.HasValue);
 
-            var nullOptional = new Optional<object>(null);
+            var nullOptional = new Optional<object>(null!);
+            Assert.False(nullOptional.HasValue);
+
+            nullOptional = new Optional<object>();
             Assert.False(nullOptional.HasValue);
         }
 
@@ -62,13 +65,13 @@ namespace Recore.Tests
 
             Assert.Throws<ArgumentNullException>(
                 () => optional.Switch(
-                    null,
+                    null!,
                     () => throw new Exception("Should not be called")));
 
             Assert.Throws<ArgumentNullException>(
                 () => optional.Switch(
                     x => throw new Exception("Should not be called"),
-                    null));
+                    null!));
         }
 
         [Fact]
@@ -93,13 +96,13 @@ namespace Recore.Tests
 
             Assert.Throws<ArgumentNullException>(
                 () => optional.Switch(
-                    null,
+                    null!,
                     () => throw new Exception("Should not be called")));
 
             Assert.Throws<ArgumentNullException>(
                 () => optional.Switch(
                     x => throw new Exception("Should not be called"),
-                    null));
+                    null!));
         }
 
         [Fact]
@@ -541,17 +544,17 @@ namespace Recore.Tests
             Assert.False(called);
             Assert.False(optional.HasValue);
 
-            Assert.Throws<ArgumentNullException>(() => Optional.If<int>(true, null));
+            Assert.Throws<ArgumentNullException>(() => Optional.If<int>(true, null!));
         }
 
         [Fact]
         public void Lift_ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(
-                () => Optional.Lift<string>(null));
+                () => Optional.Lift<string>(null!));
 
             Assert.Throws<ArgumentNullException>(
-                () => Optional.Lift<string, int>(null));
+                () => Optional.Lift<string, int>(null!));
         }
 
         [Fact]

--- a/test/Recore/OptionalTests.cs
+++ b/test/Recore/OptionalTests.cs
@@ -601,16 +601,6 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void FlattenNullable()
-        {
-            var hasValue = new Optional<int?>(1);
-            Assert.Equal(1, hasValue.Flatten());
-
-            var isNull = new Optional<int?>();
-            Assert.False(isNull.Flatten().HasValue);
-        }
-
-        [Fact]
         public void NonEmpty()
         {
             var collection = new[]

--- a/test/Recore/PipelineTests.cs
+++ b/test/Recore/PipelineTests.cs
@@ -16,7 +16,7 @@ namespace Recore.Functional.Tests
         [Fact]
         public void ThenAllFuncs()
         {
-            var result = Pipeline.Of<string>(null)
+            var result = Pipeline.Of<string?>(null)
                 .Then(string.IsNullOrEmpty)
                 .Then(x => x.ToString())
                 .Result;

--- a/test/Recore/ResultTests.cs
+++ b/test/Recore/ResultTests.cs
@@ -107,18 +107,6 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void GetValueGetError()
-        {
-            var success = Result.Success<int, string>(-5);
-            Assert.Equal(-5, success.GetValue());
-            Assert.False(success.GetError().HasValue);
-
-            var failure = Result.Failure<int, string>("hello");
-            Assert.False(failure.GetValue().HasValue);
-            Assert.Equal("hello", failure.GetError());
-        }
-
-        [Fact]
         public void OnValueOnError()
         {
             Result<int, string> result;
@@ -281,6 +269,34 @@ namespace Recore.Tests
 
             var failure = Result.Failure<int, string>("hello");
             Assert.Equal("hello", failure.ToString());
+        }
+
+        [Fact]
+        public void GetValueGetError()
+        {
+            var success = Result.Success<int, string>(-5);
+            Assert.Equal(-5, success.GetValue());
+            Assert.False(success.GetError().HasValue);
+
+            var failure = Result.Failure<int, string>("hello");
+            Assert.False(failure.GetValue().HasValue);
+            Assert.Equal("hello", failure.GetError());
+        }
+
+        [Fact]
+        public void GetLeftGetRightNullable()
+        {
+            var left = new Result<int?, string>(-5);
+            Assert.Equal(-5, left.GetValue());
+            Assert.False(left.GetError().HasValue);
+
+            left = new Result<int?, string>(value: null);
+            Assert.Null(left.GetValue());
+            Assert.False(left.GetError().HasValue);
+
+            var right = new Result<int?, string>("hello");
+            Assert.Null(right.GetValue());
+            Assert.Equal("hello", right.GetError());
         }
 
         [Fact]

--- a/test/Recore/ResultTests.cs
+++ b/test/Recore/ResultTests.cs
@@ -49,11 +49,11 @@ namespace Recore.Tests
             Assert.Throws<ArgumentNullException>(
                 () => Result.Switch(
                     value => throw new Exception("Should not be called"),
-                    null));
+                    null!));
 
             Assert.Throws<ArgumentNullException>(
                 () => Result.Switch(
-                    null,
+                    null!,
                     error => throw new Exception("Should not be called")));
         }
 
@@ -80,11 +80,11 @@ namespace Recore.Tests
             Assert.Throws<ArgumentNullException>(
                 () => result.Switch(
                     value => throw new Exception("Should not be called"),
-                    null));
+                    null!));
 
             Assert.Throws<ArgumentNullException>(
                 () => result.Switch(
-                    null,
+                    null!,
                     error => throw new Exception("Should not be called")));
         }
 
@@ -205,7 +205,7 @@ namespace Recore.Tests
         public void EqualsWithNull()
         {
             Assert.False(
-                new Result<int, string>("abc").Equals((Result<int, string>)null));
+                new Result<int, string>("abc").Equals(null!));
         }
 
         [Theory]
@@ -342,10 +342,8 @@ namespace Recore.Tests
         [Fact]
         public async Task TryCatchAsync()
         {
-            Task<int> GetNumberAsync(int n) => Task.FromResult(n);
-
             var success = await Result
-                .TryAsync(async () => await GetNumberAsync(1))
+                .TryAsync(async () => await Task.FromResult(1))
                 .CatchAsync<Exception>();
 
             Assert.Equal(1, success);
@@ -354,7 +352,7 @@ namespace Recore.Tests
             int zero = 0;
 
             var failure = await Result
-                .TryAsync<double>(async () => await GetNumberAsync(1) / zero) // throws DivideByZeroException
+                .TryAsync<double>(async () => await Task.FromResult(1) / zero) // throws DivideByZeroException
                 .CatchAsync<DivideByZeroException>();
 
             Assert.False(failure.IsSuccessful);
@@ -368,10 +366,8 @@ namespace Recore.Tests
         [Fact]
         public async Task TryCatchAsyncMap()
         {
-            Task<int> GetNumberAsync(int n) => Task.FromResult(n);
-
             var success = await Result
-                .TryAsync(async () => await GetNumberAsync(1))
+                .TryAsync(async () => await Task.FromResult(1))
                 .CatchAsync((Exception _) => Task.FromResult("failed"));
 
             Assert.Equal(1, success);

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -11,7 +11,7 @@ namespace Recore.Tests
         [Fact]
         public void NullNotAllowed()
         {
-            Assert.Throws<ArgumentNullException>(() => new Token(null));
+            Assert.Throws<ArgumentNullException>(() => new Token(null!));
         }
 
         [Fact]


### PR DESCRIPTION
Closes #24

- Upgrade to .NET Standard 2.1 and C# 8.0
- Make `GetLeft()`, etc. extension methods