### PR TITLE
Add nullable annotations for Argmax and Argmin

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -21,6 +21,12 @@ steps:
 - script: dotnet build --configuration Release
   displayName: dotnet build
 
+  - task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
+  inputs:
+    version: '3.1.402'
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - script: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"
   displayName: dotnet test
 

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -21,12 +21,6 @@ steps:
 - script: dotnet build --configuration Release
   displayName: dotnet build
 
-  - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK'
-  inputs:
-    version: '3.1.402'
-    installationPath: $(Agent.ToolsDirectory)/dotnet
-
 - script: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"
   displayName: dotnet test
 

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -15,7 +15,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: '3.1.402'
+    version: '5.0'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet build --configuration Release

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -15,7 +15,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: '5.0'
+    version: '5.0.100-rc.1.20452.10'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet build --configuration Release

--- a/.azure/pipelines/docs.yml
+++ b/.azure/pipelines/docs.yml
@@ -9,7 +9,7 @@ steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: '5.0'
+      version: '5.0.100-rc.1.20452.10'
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - script: dotnet restore

--- a/.azure/pipelines/docs.yml
+++ b/.azure/pipelines/docs.yml
@@ -9,7 +9,7 @@ steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: '3.1.402'
+      version: '5.0'
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - script: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,10 @@ jobs:
     - name: dotnet build
       run: dotnet build --configuration Release
 
+    - name: Set up .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.402'
+
     - name: dotnet test
       run: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,5 @@ jobs:
     - name: dotnet build
       run: dotnet build --configuration Release
 
-    - name: Set up .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.402'
-
     - name: dotnet test
       run: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.402'
+        dotnet-version: '5.0'
 
     - name: dotnet build
       run: dotnet build --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0'
+        dotnet-version: '5.0.100-rc.1.20452.10'
 
     - name: dotnet build
       run: dotnet build --configuration Release

--- a/src/Recore.Linq/Argmax.cs
+++ b/src/Recore.Linq/Argmax.cs
@@ -516,8 +516,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the index of the maximum value from a sequence of values.
         /// </summary>
-        // TODO C# 9.0: this should be TSource? Max
-        public static (int Argmax, TSource Max) Argmax<TSource>(this IEnumerable<TSource> source)
+        public static (int Argmax, TSource? Max) Argmax<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
             {
@@ -525,7 +524,7 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            (int Index, TSource Item) value = (0, default);
+            (int Index, TSource? Item) value = (0, default);
             if (value.Item == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
@@ -571,7 +570,7 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        if (comparer.Compare(e.Current.Item, value.Item) > 0)
+                        if (comparer.Compare(e.Current.Item, value.Item!) > 0)
                         {
                             value = e.Current;
                         }
@@ -625,7 +624,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="int"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmax, int? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
+        public static (TSource? Argmax, int? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
             if (source is null)
             {
@@ -637,7 +636,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate = default;
+            TSource? argmaxCandidate = default;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -748,7 +747,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="long"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmax, long? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
+        public static (TSource? Argmax, long? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
             if (source is null)
             {
@@ -760,7 +759,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate = default;
+            TSource? argmaxCandidate = default;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -875,7 +874,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="float"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmax, float? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
+        public static (TSource? Argmax, float? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
             if (source is null)
             {
@@ -887,7 +886,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate = default;
+            TSource? argmaxCandidate = default;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -1005,7 +1004,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="double"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmax, double? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
+        public static (TSource? Argmax, double? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
             if (source is null)
             {
@@ -1017,7 +1016,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate = default;
+            TSource? argmaxCandidate = default;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -1120,7 +1119,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function returning nullable <see cref="decimal"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmax, decimal? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
+        public static (TSource? Argmax, decimal? Max) Argmax<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
             if (source is null)
             {
@@ -1132,7 +1131,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argmaxCandidate = default;
+            TSource? argmaxCandidate = default;
             decimal? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -1177,8 +1176,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the maximum value and the maximizing value for a function on a sequence of values.
         /// </summary>
-        // TODO C# 9.0: this should be (TSource? Argmax, TResult? Max)
-        public static (TSource Argmax, TResult Max) Argmax<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
+        public static (TSource? Argmax, TResult? Max) Argmax<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
             if (source is null)
             {
@@ -1191,8 +1189,8 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            TSource argmaxCandidate = default;
-            TResult value = default;
+            TSource? argmaxCandidate = default;
+            TResult? value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())

--- a/src/Recore.Linq/Argmin.cs
+++ b/src/Recore.Linq/Argmin.cs
@@ -473,8 +473,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the index of the minimum value from a sequence of values.
         /// </summary>
-        // TODO C# 9.0: this should be TSource? Min
-        public static (int Argmin, TSource Min) Argmin<TSource>(this IEnumerable<TSource> source)
+        public static (int Argmin, TSource? Min) Argmin<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
             {
@@ -482,7 +481,7 @@ namespace Recore.Linq
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
-            (int Index, TSource Item) value = (0, default);
+            (int Index, TSource? Item) value = (0, default);
             if (value.Item == null)
             {
                 using (var e = source.Enumerate().GetEnumerator())
@@ -528,7 +527,7 @@ namespace Recore.Linq
                     value = e.Current;
                     while (e.MoveNext())
                     {
-                        if (comparer.Compare(e.Current.Item, value.Item) < 0)
+                        if (comparer.Compare(e.Current.Item, value.Item!) < 0)
                         {
                             value = e.Current;
                         }
@@ -582,7 +581,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="int"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmin, int? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
+        public static (TSource? Argmin, int? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
             if (source is null)
             {
@@ -594,7 +593,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate = default;
+            TSource? argminCandidate = default;
             int? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -685,7 +684,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="long"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmin, long? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
+        public static (TSource? Argmin, long? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
             if (source is null)
             {
@@ -697,7 +696,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate = default;
+            TSource? argminCandidate = default;
             long? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -803,7 +802,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="float"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmin, float? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
+        public static (TSource? Argmin, float? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
             if (source is null)
             {
@@ -815,7 +814,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate = default;
+            TSource? argminCandidate = default;
             float? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -921,7 +920,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="double"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmin, double? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
+        public static (TSource? Argmin, double? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
             if (source is null)
             {
@@ -933,7 +932,7 @@ namespace Recore.Linq
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            TSource argminCandidate = default;
+            TSource? argminCandidate = default;
             double? value = null;
             using (var e = source.GetEnumerator())
             {
@@ -1030,7 +1029,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function returning nullable <see cref="decimal"/> on a sequence of values.
         /// </summary>
-        public static (TSource Argmin, decimal? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
+        public static (TSource? Argmin, decimal? Min) Argmin<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
             if (source is null)
             {
@@ -1087,8 +1086,7 @@ namespace Recore.Linq
         /// <summary>
         /// Returns the minimum value and the minimizing value for a function on a sequence of values.
         /// </summary>
-        // TODO C# 9.0: this should be (TSource? Argmin, TResult? Min)
-        public static (TSource Argmin, TResult Min) Argmin<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
+        public static (TSource? Argmin, TResult? Min) Argmin<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
             if (source is null)
             {
@@ -1101,8 +1099,8 @@ namespace Recore.Linq
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;
-            TSource argminCandidate = default;
-            TResult value = default;
+            TSource? argminCandidate = default;
+            TResult? value = default;
             if (value == null)
             {
                 using (var e = source.GetEnumerator())

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -23,7 +23,7 @@ namespace Recore.Linq.Tests
         [Fact]
         public void EmptyEnumerable()
         {
-            // Non-nullable TSource throws
+            // With no selector, always throws
             Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<int>().Argmax().Argmax);
 
@@ -123,6 +123,10 @@ namespace Recore.Linq.Tests
                 null,
                 null
             };
+
+            Assert.Equal(
+                (Argmax: 1, Max: null),
+                collection.Argmax());
 
             Assert.Equal(
                 (Argmax: null, Max: null),

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -136,15 +136,17 @@ namespace Recore.Linq.Tests
                 collection.Argmax(x => x?.Length));
         }
 
+        // This test was added in the past to expose a compile-time bug
+        // where you wouldn't get a warning that you were derefencing a possibly null value.
+        // `Argmax()` is now annotated correctly, so the warning is silenced with `!`.
+        // There's nothing wrong with keeping the test though.
         [Fact]
         public void ArgmaxGenericNRE()
         {
-            var collection = new string[]
-            {
-            };
+            var collection = Enumerable.Empty<string?>();
 
             var argmax = collection.Argmax(x => x?.Length).Argmax;
-            Assert.Throws<NullReferenceException>(() => argmax.Length);
+            Assert.Throws<NullReferenceException>(() => argmax!.Length);
         }
 
         [Fact]

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -143,8 +143,9 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ArgmaxGenericNRE()
         {
-            var collection = Enumerable.Empty<string?>();
+            var collection = Enumerable.Empty<string>();
 
+            // The unneeded `?.` operator makes the result `int?`
             var argmax = collection.Argmax(x => x?.Length).Argmax;
             Assert.Throws<NullReferenceException>(() => argmax!.Length);
         }

--- a/test/Recore.Linq/ArgmaxTests.cs
+++ b/test/Recore.Linq/ArgmaxTests.cs
@@ -28,6 +28,9 @@ namespace Recore.Linq.Tests
                 () => Enumerable.Empty<int>().Argmax().Argmax);
 
             Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<Guid>().Argmax().Argmax);
+
+            Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<string>().Argmax().Argmax);
 
             // When one or both of TSource and TResult is non-nullable, throws
@@ -142,6 +145,36 @@ namespace Recore.Linq.Tests
 
             var argmax = collection.Argmax(x => x?.Length).Argmax;
             Assert.Throws<NullReferenceException>(() => argmax.Length);
+        }
+
+        [Fact]
+        public void ArgmaxGenericValueType()
+        {
+            var guids = new[]
+            {
+                Guid.NewGuid()
+            };
+
+            // Don't change this to `var`;
+            // we want to test that this doesn't turn into `Guid?`
+            Guid max = guids.Argmax().Max;
+            Assert.Equal(guids[0], max);
+            var argmax = guids.Argmax(x => x.ToString().Length);
+        }
+
+        [Fact]
+        public void ArgmaxGenericValueType_Selector()
+        {
+            var guids = new[]
+            {
+                Guid.NewGuid()
+            };
+
+            // Don't change this to `var`;
+            // we want to test that this doesn't turn into `Guid?`
+            (Guid argmax, Guid max) =  guids.Argmax(x => x);
+            Assert.Equal(guids[0], argmax);
+            Assert.Equal(guids[0], max);
         }
 
         [Property]

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -125,6 +125,10 @@ namespace Recore.Linq.Tests
             };
 
             Assert.Equal(
+                (Argmin: 1, Min: null),
+                collection.Argmin());
+
+            Assert.Equal(
                 (Argmin: null, Min: null),
                 collection.Argmin(x => x?.Length));
         }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -143,8 +143,9 @@ namespace Recore.Linq.Tests
         [Fact]
         public void ArgminGenericNRE()
         {
-            var collection = Enumerable.Empty<string?>();
+            var collection = Enumerable.Empty<string>();
 
+            // The unneeded `?.` operator makes the result `int?`
             var argmin = collection.Argmin(x => x?.Length).Argmin;
             Assert.Throws<NullReferenceException>(() => argmin!.Length);
         }

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -136,15 +136,17 @@ namespace Recore.Linq.Tests
                 collection.Argmin(x => x?.Length));
         }
 
+        // This test was added in the past to expose a compile-time bug
+        // where you wouldn't get a warning that you were derefencing a possibly null value.
+        // `Argmin()` is now annotated correctly, so the warning is silenced with `!`.
+        // There's nothing wrong with keeping the test though.
         [Fact]
         public void ArgminGenericNRE()
         {
-            var collection = new string[]
-            {
-            };
+            var collection = Enumerable.Empty<string?>();
 
             var argmin = collection.Argmin(x => x?.Length).Argmin;
-            Assert.Throws<NullReferenceException>(() => argmin.Length);
+            Assert.Throws<NullReferenceException>(() => argmin!.Length);
         }
 
         [Fact]

--- a/test/Recore.Linq/ArgminTests.cs
+++ b/test/Recore.Linq/ArgminTests.cs
@@ -28,6 +28,9 @@ namespace Recore.Linq.Tests
                 () => Enumerable.Empty<int>().Argmin().Argmin);
 
             Assert.Throws<InvalidOperationException>(
+                () => Enumerable.Empty<Guid>().Argmin().Argmin);
+
+            Assert.Throws<InvalidOperationException>(
                 () => Enumerable.Empty<string>().Argmin().Argmin);
 
             // When one or both of TSource and TResult is non-nullable, throws
@@ -101,7 +104,7 @@ namespace Recore.Linq.Tests
         }
 
         [Fact]
-        public void ArgmaxGenericWithNull()
+        public void ArgminGenericWithNull()
         {
             var collection = new[]
             {
@@ -142,6 +145,36 @@ namespace Recore.Linq.Tests
 
             var argmin = collection.Argmin(x => x?.Length).Argmin;
             Assert.Throws<NullReferenceException>(() => argmin.Length);
+        }
+
+        [Fact]
+        public void ArgminGenericValueType()
+        {
+            var guids = new[]
+            {
+                Guid.NewGuid()
+            };
+
+            // Don't change this to `var`;
+            // we want to test that this doesn't turn into `Guid?`
+            Guid min = guids.Argmin().Min;
+            Assert.Equal(guids[0], min);
+            var argmin = guids.Argmin(x => x.ToString().Length);
+        }
+
+        [Fact]
+        public void ArgminGenericValueType_Selector()
+        {
+            var guids = new[]
+            {
+                Guid.NewGuid()
+            };
+
+            // Don't change this to `var`;
+            // we want to test that this doesn't turn into `Guid?`
+            (Guid argmin, Guid min) =  guids.Argmin(x => x);
+            Assert.Equal(guids[0], argmin);
+            Assert.Equal(guids[0], min);
         }
 
         [Property]

--- a/test/Recore.Tests.csproj
+++ b/test/Recore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Recore.Tests</RootNamespace>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This requires C# 9's new `T?` annotations for unconstrained generic types.  This follows how `Max()` and `Min()` [are annotated](https://github.com/dotnet/runtime/blob/63c3dd18f0f482b519afb152c04b84af6c4ffaf9/src/libraries/System.Linq/src/System/Linq/Max.cs#L444).

For simplicity in the CI builds, this goes ahead and upgrades the tests to .NET 5.0.  This produces some warnings which will need to be fixed later.