### PR TITLE
Target .NET 5.0

### DIFF
--- a/docs/changelogs/v2.0.0.md
+++ b/docs/changelogs/v2.0.0.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- RecoreFX now targets .NET Standard 2.1
+- RecoreFX now targets .NET 5.0.
 
 
 ## New features

--- a/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
@@ -18,7 +18,7 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Creates an instance of <see cref="AnonymousEqualityComparer{T}"/>.
         /// </summary>
-        public AnonymousEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode)
+        public AnonymousEqualityComparer(Func<T?, T?, bool> equals, Func<T, int> getHashCode)
         {
             this.equals = equals ?? throw new ArgumentNullException(nameof(equals));
             this.getHashCode = getHashCode ?? throw new ArgumentNullException(nameof(getHashCode));
@@ -27,7 +27,7 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Invokes the given comparison function on two objects.
         /// </summary>
-        public bool Equals(T x, T y) => equals(x, y);
+        public bool Equals(T? x, T? y) => equals(x, y);
 
 
         /// <summary>

--- a/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/AnonymousEqualityComparer.cs
@@ -12,7 +12,7 @@ namespace Recore.Collections.Generic
     /// </remarks>
     public sealed class AnonymousEqualityComparer<T> : IEqualityComparer<T>
     {
-        private readonly Func<T, T, bool> equals;
+        private readonly Func<T?, T?, bool> equals;
         private readonly Func<T, int> getHashCode;
 
         /// <summary>

--- a/src/Recore.Collections.Generic/IDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IDictionaryExtensions.cs
@@ -18,6 +18,7 @@ namespace Recore.Collections.Generic
         /// </remarks>
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
+        where TKey : notnull
         {
             if (dict.TryGetValue(key, out TValue value))
             {
@@ -39,6 +40,7 @@ namespace Recore.Collections.Generic
         /// </remarks>
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
+        where TKey : notnull
         {
             return dict.StaticCast<IDictionary<TKey, TValue>>().GetValueOrDefault(key);
         }
@@ -47,6 +49,7 @@ namespace Recore.Collections.Generic
         /// Adds an entry to the <see cref="IDictionary{TKey, TValue}"/> and passes the dictionary through.
         /// </summary>
         public static IDictionary<TKey, TValue> Append<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
+        where TKey : notnull
         {
             dict.Add(key, value);
             return dict;
@@ -64,6 +67,7 @@ namespace Recore.Collections.Generic
         /// This will be either the existing value for the key if the key is already in the dictionary, or the new value if the key was not in the dictionary.
         /// </returns>
         public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
+        where TKey : notnull
         {
             if (dict.TryGetValue(key, out TValue result))
             {
@@ -81,6 +85,7 @@ namespace Recore.Collections.Generic
         /// Existing elements are overwritten if there are duplicates.
         /// </summary>
         public static void AddRange<TKey, TValue>(this IDictionary<TKey, TValue> dict, IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        where TKey : notnull
         {
             if (collection is null)
             {

--- a/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
+++ b/src/Recore.Collections.Generic/IReadOnlyDictionaryExtensions.cs
@@ -14,6 +14,7 @@ namespace Recore.Collections.Generic
         /// </summary>
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key)
+        where TKey : notnull
         {
             if (dict.TryGetValue(key, out TValue value))
             {
@@ -35,6 +36,7 @@ namespace Recore.Collections.Generic
         /// </remarks>
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this ReadOnlyDictionary<TKey, TValue> dict, TKey key)
+        where TKey : notnull
         {
             return dict.StaticCast<IReadOnlyDictionary<TKey, TValue>>().GetValueOrDefault(key);
         }

--- a/src/Recore.Collections.Generic/MappedComparer.cs
+++ b/src/Recore.Collections.Generic/MappedComparer.cs
@@ -23,6 +23,11 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Compares the mapped output of two objects.
         /// </summary>
-        public int Compare(T? x, T? y) => mappingComparer.Compare(mapping(x), mapping(y));
+        public int Compare(T? x, T? y)
+        {
+            U? mappedX = x == null ? default(U?) : mapping(x);
+            U? mappedY = y == null ? default(U?) : mapping(y);
+            return mappingComparer.Compare(mappedX, mappedY);
+        }
     }
 }

--- a/src/Recore.Collections.Generic/MappedComparer.cs
+++ b/src/Recore.Collections.Generic/MappedComparer.cs
@@ -23,6 +23,6 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Compares the mapped output of two objects.
         /// </summary>
-        public int Compare(T x, T y) => mappingComparer.Compare(mapping(x), mapping(y));
+        public int Compare(T? x, T? y) => mappingComparer.Compare(mapping(x), mapping(y));
     }
 }

--- a/src/Recore.Collections.Generic/MappedEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/MappedEqualityComparer.cs
@@ -23,7 +23,7 @@ namespace Recore.Collections.Generic
         /// <summary>
         /// Invokes the mapping function on two objects and checks if the outputs are equal.
         /// </summary>
-        public bool Equals(T x, T y)
+        public bool Equals(T? x, T? y)
             => mappingComparer.Equals(mapping(x), mapping(y));
 
         /// <summary>

--- a/src/Recore.Collections.Generic/MappedEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/MappedEqualityComparer.cs
@@ -24,7 +24,11 @@ namespace Recore.Collections.Generic
         /// Invokes the mapping function on two objects and checks if the outputs are equal.
         /// </summary>
         public bool Equals(T? x, T? y)
-            => mappingComparer.Equals(mapping(x), mapping(y));
+        {
+            U? mappedX = x == null ? default(U?) : mapping(x);
+            U? mappedY = y == null ? default(U?) : mapping(y);
+            return mappingComparer.Equals(mappedX, mappedY);
+        }
 
         /// <summary>
         /// Hashes the mapped output of an object.

--- a/src/Recore.Collections.Generic/MappedEqualityComparer.cs
+++ b/src/Recore.Collections.Generic/MappedEqualityComparer.cs
@@ -34,6 +34,16 @@ namespace Recore.Collections.Generic
         /// Hashes the mapped output of an object.
         /// </summary>
         public int GetHashCode(T obj)
-            => mappingComparer.GetHashCode(mapping(obj));
+        {
+            var mapped = mapping(obj);
+            if (mapped == null)
+            {
+                return 0;
+            }
+            else
+            {
+                return mappingComparer.GetHashCode(mapped);
+            }
+        }
     }
 }

--- a/src/Recore.Linq/KeyValuePair.cs
+++ b/src/Recore.Linq/KeyValuePair.cs
@@ -19,6 +19,7 @@ namespace Recore.Linq
         public static IEnumerable<KeyValuePair<TResult, TValue>> OnKeys<TKey, TValue, TResult>(
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TKey, TResult> func)
+        where TResult : notnull
         {
             if (source is null)
             {
@@ -40,6 +41,7 @@ namespace Recore.Linq
         public static IEnumerable<KeyValuePair<TKey, TResult>> OnValues<TKey, TValue, TResult>(
             this IEnumerable<KeyValuePair<TKey, TValue>> source,
             Func<TValue, TResult> func)
+        where TKey : notnull
         {
             if (source is null)
             {

--- a/src/Recore.Linq/KeyValuePair.cs
+++ b/src/Recore.Linq/KeyValuePair.cs
@@ -10,6 +10,7 @@ namespace Recore.Linq
         /// Creates a <see cref="Dictionary{TKey, TValue}"/> from a sequence of key-value pairs.
         /// </summary>
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
+        where TKey : notnull
             => source.ToDictionary(x => x.Key, x => x.Value);
 
         /// <summary>

--- a/src/Recore.Text.Json.Serialization.Converters/EitherConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/EitherConverter.cs
@@ -21,6 +21,13 @@ namespace Recore.Text.Json.Serialization.Converters
             var eitherConverter = Activator.CreateInstance(
                 type: typeof(EitherConverter<,>).MakeGenericType(new[] { leftType, rightType }));
 
+            if (eitherConverter is null)
+            {
+                // According to the docs, `CreateInstance` should return `null`
+                // only if the type is some `Nullable<T>`
+                throw new InvalidOperationException();
+            }
+
             return (JsonConverter)eitherConverter;
         }
     }
@@ -36,7 +43,7 @@ namespace Recore.Text.Json.Serialization.Converters
             // Read the whole string in as JSON to avoid the case where the first converter partially succeeds
             // and then the reader is stuck in the middle of the JSON.
             var jsonDocument = JsonDocument.ParseValue(ref reader);
-            var json = jsonDocument.RootElement.ToString();
+            var json = jsonDocument.RootElement.ToString()!;
 
             // `ToString()` for a string type will return the string *without* quotes,
             // which won't deserialize correctly.
@@ -49,11 +56,11 @@ namespace Recore.Text.Json.Serialization.Converters
             // but it seems to be the only way in this case.
             try
             {
-                return JsonSerializer.Deserialize<TLeft>(json, options);
+                return JsonSerializer.Deserialize<TLeft>(json, options)!;
             }
             catch (JsonException)
             {
-                return JsonSerializer.Deserialize<TRight>(json, options);
+                return JsonSerializer.Deserialize<TRight>(json, options)!;
             }
         }
 
@@ -96,7 +103,7 @@ namespace Recore.Text.Json.Serialization.Converters
         public override Either<TLeft, TRight> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var jsonDocument = JsonDocument.ParseValue(ref reader);
-            var json = jsonDocument.RootElement.ToString();
+            var json = jsonDocument.RootElement.ToString()!;
 
             // `ToString()` for a string type will return the string *without* quotes,
             // which won't deserialize correctly.
@@ -107,11 +114,11 @@ namespace Recore.Text.Json.Serialization.Converters
 
             if (deserializeAsLeft(jsonDocument.RootElement))
             {
-                return JsonSerializer.Deserialize<TLeft>(json, options);
+                return JsonSerializer.Deserialize<TLeft>(json, options)!;
             }
             else
             {
-                return JsonSerializer.Deserialize<TRight>(json, options);
+                return JsonSerializer.Deserialize<TRight>(json, options)!;
             }
         }
 

--- a/src/Recore.Text.Json.Serialization.Converters/OfConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/OfConverter.cs
@@ -22,6 +22,13 @@ namespace Recore.Text.Json.Serialization.Converters
                 var ofConverter = Activator.CreateInstance(
                     type: typeof(OfConverter<>).MakeGenericType(new[] { innerType }));
 
+                if (ofConverter is null)
+                {
+                    // According to the docs, `CreateInstance` should return `null`
+                    // only if the type is some `Nullable<T>`
+                    throw new InvalidOperationException();
+                }
+
                 return (JsonConverter)ofConverter;
             }
             else

--- a/src/Recore.Text.Json.Serialization.Converters/OptionalConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/OptionalConverter.cs
@@ -19,6 +19,13 @@ namespace Recore.Text.Json.Serialization.Converters
             var optionalConverter = Activator.CreateInstance(
                 type: typeof(OptionalConverter<>).MakeGenericType(new[] { innerType }));
 
+            if (optionalConverter is null)
+            {
+                // According to the docs, `CreateInstance` should return `null`
+                // only if the type is some `Nullable<T>`
+                throw new InvalidOperationException();
+            }
+
             return (JsonConverter)optionalConverter;
         }
     }
@@ -37,7 +44,7 @@ namespace Recore.Text.Json.Serialization.Converters
             }
             else
             {
-                var innerValue = JsonSerializer.Deserialize<T>(ref reader, options);
+                var innerValue = JsonSerializer.Deserialize<T>(ref reader, options)!;
                 return Optional.Of(innerValue);
             }
         }

--- a/src/Recore.Text.Json.Serialization.Converters/ResultConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/ResultConverter.cs
@@ -21,6 +21,13 @@ namespace Recore.Text.Json.Serialization.Converters
             var resultConverter = Activator.CreateInstance(
                 type: typeof(ResultConverter<,>).MakeGenericType(new[] { valueType, errorType }));
 
+            if (resultConverter is null)
+            {
+                // According to the docs, `CreateInstance` should return `null`
+                // only if the type is some `Nullable<T>`
+                throw new InvalidOperationException();
+            }
+
             return (JsonConverter)resultConverter;
         }
     }
@@ -36,7 +43,7 @@ namespace Recore.Text.Json.Serialization.Converters
             // Read the whole string in as JSON to avoid the case where the first converter partially succeeds
             // and then the reader is stuck in the middle of the JSON.
             var jsonDocument = JsonDocument.ParseValue(ref reader);
-            var json = jsonDocument.RootElement.ToString();
+            var json = jsonDocument.RootElement.ToString()!;
 
             // `ToString()` for a string type will return the string *without* quotes,
             // which won't deserialize correctly.
@@ -49,11 +56,11 @@ namespace Recore.Text.Json.Serialization.Converters
             // but it seems to be the only way in this case.
             try
             {
-                return JsonSerializer.Deserialize<TValue>(json, options);
+                return JsonSerializer.Deserialize<TValue>(json, options)!;
             }
             catch (JsonException)
             {
-                return JsonSerializer.Deserialize<TError>(json, options);
+                return JsonSerializer.Deserialize<TError>(json, options)!;
             }
         }
 
@@ -96,7 +103,7 @@ namespace Recore.Text.Json.Serialization.Converters
         public override Result<TValue, TError> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var jsonDocument = JsonDocument.ParseValue(ref reader);
-            var json = jsonDocument.RootElement.ToString();
+            var json = jsonDocument.RootElement.ToString()!;
 
             // `ToString()` for a string type will return the string *without* quotes,
             // which won't deserialize correctly.
@@ -107,11 +114,11 @@ namespace Recore.Text.Json.Serialization.Converters
 
             if (deserializeAsValue(jsonDocument.RootElement))
             {
-                return JsonSerializer.Deserialize<TValue>(json, options);
+                return JsonSerializer.Deserialize<TValue>(json, options)!;
             }
             else
             {
-                return JsonSerializer.Deserialize<TError>(json, options);
+                return JsonSerializer.Deserialize<TError>(json, options)!;
             }
         }
 

--- a/src/Recore.Text.Json.Serialization.Converters/UriConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/UriConverter.cs
@@ -10,7 +10,12 @@ namespace Recore.Text.Json.Serialization.Converters
     {
         public override AbsoluteUri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            string uriString = reader.GetString();
+            string? uriString = reader.GetString();
+            if (uriString is null)
+            {
+                throw new JsonException();
+            }
+
             if (AbsoluteUri.TryCreate(uriString, out AbsoluteUri? value))
             {
                 return value;
@@ -29,7 +34,12 @@ namespace Recore.Text.Json.Serialization.Converters
     {
         public override RelativeUri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            string uriString = reader.GetString();
+            string? uriString = reader.GetString();
+            if (uriString is null)
+            {
+                throw new JsonException();
+            }
+
             if (RelativeUri.TryCreate(uriString, out RelativeUri? value))
             {
                 return value;

--- a/src/Recore.csproj
+++ b/src/Recore.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <RootNamespace>Recore</RootNamespace>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -195,7 +195,7 @@ namespace Recore
         /// For example, an <c>Either&lt;int, string&gt;</c> and an <c>Either&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Either<TLeft, TRight> either
             && this.Equals(either);
 
@@ -209,7 +209,7 @@ namespace Recore
         /// For example, <c>Either&lt;Color, Day&gt;(Color.Red) != Either&lt;Color, Day&gt;(Day.Monday)</c>
         /// even if <c>Color.Red == Day.Monday</c>.
         /// </remarks>
-        public bool Equals(Either<TLeft, TRight> other)
+        public bool Equals(Either<TLeft, TRight>? other)
             => !(other is null)
             && Switch(
                 l => other.Switch(

--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -181,10 +181,12 @@ namespace Recore
         /// <summary>
         /// Returns the string representation of the underlying value.
         /// </summary>
+        #nullable disable // Set to oblivious because TLeft / TRight.ToString() is oblivious
         public override string ToString()
             => Switch(
                 l => l!.ToString(),
                 r => r!.ToString());
+        #nullable enable
 
         /// <summary>
         /// Compares this <see cref="Either{TLeft, TRight}"/>

--- a/src/Recore/Of.cs
+++ b/src/Recore/Of.cs
@@ -51,7 +51,7 @@ namespace Recore
         /// <summary>
         /// Determines whether this instance is equal to another object.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Of<T> of && Equals(of);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Recore
         /// Note that instances of two separate subtypes of <see cref="Of{T}"/>
         /// will compare equal to each other if their values are the same type and are equal.
         /// </remarks>
-        public bool Equals(Of<T> other)
+        public bool Equals(Of<T>? other)
             => !(other is null)
             && Equals(Value, other.Value);
 

--- a/src/Recore/Of.cs
+++ b/src/Recore/Of.cs
@@ -46,7 +46,9 @@ namespace Recore
         /// <summary>
         /// Returns the string representation for the underlying object.
         /// </summary>
+        #nullable disable // Set to oblivious because T.ToString() is oblivious
         public override string ToString() => Value!.ToString();
+        #nullable enable
 
         /// <summary>
         /// Determines whether this instance is equal to another object.

--- a/src/Recore/Of.cs
+++ b/src/Recore/Of.cs
@@ -34,7 +34,7 @@ namespace Recore
         /// <summary>
         /// The underlying instance of the wrapped type.
         /// </summary>
-        public T Value { get; set; } = default!;
+        public T? Value { get; set; } = default;
 
         /// <summary>
         /// Converts this <see cref="Of{T}"/> to another subtype of <see cref="Of{T}"/>
@@ -47,7 +47,17 @@ namespace Recore
         /// Returns the string representation for the underlying object.
         /// </summary>
         #nullable disable // Set to oblivious because T.ToString() is oblivious
-        public override string ToString() => Value!.ToString();
+        public override string ToString()
+        {
+            if (Value == null)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return Value.ToString();
+            }
+        }
         #nullable enable
 
         /// <summary>
@@ -91,6 +101,6 @@ namespace Recore
         /// <see cref="Of{T}"/> is conceptually (though not in fact) a subtype of <typeparamref name="T"/>.
         /// This conversion allows instances of <see cref="Of{T}"/> to work with methods out of the caller's control.
         /// </remarks>
-        public static implicit operator T(Of<T> of) => of.Value;
+        public static implicit operator T?(Of<T> of) => of.Value;
     }
 }

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -192,7 +192,7 @@ namespace Recore
         /// which must also be an <see cref="Optional{T}"/>,
         /// have the same value.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Optional<T> optional
             && this.Equals(optional);
 

--- a/src/Recore/Optional.cs
+++ b/src/Recore/Optional.cs
@@ -173,10 +173,12 @@ namespace Recore
         /// <summary>
         /// Returns the value's string representation, or a localized "none" message.
         /// </summary>
+        #nullable disable // Set to oblivious because T.ToString() is oblivious
         public override string ToString()
             => Switch(
-                x => x!.ToString(),
+                x => x.ToString(),
                 () => Resources.OptionalEmptyToString);
+        #nullable enable
 
         /// <summary>
         /// Returns the hash code for the underlying type

--- a/src/Recore/Result.cs
+++ b/src/Recore/Result.cs
@@ -148,7 +148,7 @@ namespace Recore
         /// For example, an <c>Result&lt;int, string&gt;</c> and an <c>Result&lt;string, int&gt;</c>
         /// will always be nonequal.
         /// </remarks>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Result<TValue, TError> result
             && this.Equals(result);
 
@@ -159,7 +159,7 @@ namespace Recore
         /// <remarks>
         /// Equality is defined as both objects' underlying values or errors being equal.
         /// </remarks>
-        public bool Equals(Result<TValue, TError> other)
+        public bool Equals(Result<TValue, TError>? other)
             => !(other is null)
             && this.either == other.either;
 

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -45,14 +45,14 @@ namespace Recore
         /// have the same value.
         /// A parameter specifies the culture, case, and sort rules used in the comparison.
         /// </summary>
-        public bool Equals(Of<string>? other, StringComparison comparisonType) => Value.Equals(other?.Value, comparisonType);
+        public bool Equals(Of<string>? other, StringComparison comparisonType) => Value!.Equals(other?.Value, comparisonType);
 
         /// <summary>
         /// Compares this instance with a specified <see cref="Token"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
-        public int CompareTo(Of<string>? other) => Value.CompareTo(other?.Value);
+        public int CompareTo(Of<string>? other) => Value!.CompareTo(other?.Value);
 
         // For some reason, String implements IComparable but does not have comparison operators.
         // Therefore, I won't add them to Token, either.

--- a/src/Recore/Token.cs
+++ b/src/Recore/Token.cs
@@ -45,14 +45,14 @@ namespace Recore
         /// have the same value.
         /// A parameter specifies the culture, case, and sort rules used in the comparison.
         /// </summary>
-        public bool Equals(Of<string> other, StringComparison comparisonType) => Value.Equals(other.Value, comparisonType);
+        public bool Equals(Of<string>? other, StringComparison comparisonType) => Value.Equals(other?.Value, comparisonType);
 
         /// <summary>
         /// Compares this instance with a specified <see cref="Token"/> object
         /// and indicates whether this instance precedes, follows, or appears in the same position
         /// in the sort order as the specified object.
         /// </summary>
-        public int CompareTo(Of<string> other) => Value.CompareTo(other.Value);
+        public int CompareTo(Of<string>? other) => Value.CompareTo(other?.Value);
 
         // For some reason, String implements IComparable but does not have comparison operators.
         // Therefore, I won't add them to Token, either.

--- a/src/Recore/Unit.cs
+++ b/src/Recore/Unit.cs
@@ -40,7 +40,7 @@ namespace Recore
         /// <summary>
         /// Determines whether another object is the unit value.
         /// </summary>
-        public override bool Equals(object obj) => obj is Unit;
+        public override bool Equals(object? obj) => obj is Unit;
 
         /// <summary>
         /// Two unit instances are always equal.

--- a/src/Recore/Uri.cs
+++ b/src/Recore/Uri.cs
@@ -35,7 +35,7 @@ namespace Recore
         public static bool TryCreate(string uriString, [NotNullWhen(true)] out AbsoluteUri? result)
         {
             result = null;
-            if (TryCreate(uriString, UriKind.Absolute, out Uri value))
+            if (TryCreate(uriString, UriKind.Absolute, out Uri? value))
             {
                 result = value.AsAbsoluteUri()!;
                 return true;
@@ -64,7 +64,7 @@ namespace Recore
         public static bool TryCreate(string uriString, [NotNullWhen(true)] out RelativeUri? result)
         {
             result = null;
-            if (TryCreate(uriString, UriKind.Relative, out Uri value))
+            if (TryCreate(uriString, UriKind.Relative, out Uri? value))
             {
                 result = value.AsRelativeUri()!;
                 return true;

--- a/test/Recore.Collections.Generic/AnonymousEqualityComparerTests.cs
+++ b/test/Recore.Collections.Generic/AnonymousEqualityComparerTests.cs
@@ -41,8 +41,8 @@ namespace Recore.Tests.Recore.Collections.Generic
             // Compare on Name and Age
             var equalityComparer = new AnonymousEqualityComparer<Person>(
                 (x, y) =>
-                    x.Name == y.Name
-                    && x.Age == y.Age,
+                    x?.Name == y?.Name
+                    && x?.Age == y?.Age,
                 x => HashCode.Combine(x.Name, x.Age));
 
             Assert.Equal(persons, morePersons, equalityComparer);

--- a/test/Recore.Collections.Generic/MappedComparerTests.cs
+++ b/test/Recore.Collections.Generic/MappedComparerTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Recore.Collections.Generic;
 using Xunit;
 
-namespace Recore.Tests.Recore.Collections.Generic
+namespace Recore.Collections.Generic.Tests
 {
     public class MappedComparerTests
     {
@@ -31,7 +30,6 @@ namespace Recore.Tests.Recore.Collections.Generic
                 new Person { Id = 2, Name = "C", Age = 52 }
             };
 
-
             var byAge = new MappedComparer<Person, int>(x => x.Age);
             persons.Sort(byAge);
 
@@ -43,6 +41,17 @@ namespace Recore.Tests.Recore.Collections.Generic
                 x => HashCode.Combine(x.Name, x.Age));
 
             Assert.Equal(sortedPersons, persons, equalityComparer);
+        }
+
+        [Theory]
+        [InlineData("hello", "world", 0)]
+        [InlineData("hello", null, 1)]
+        [InlineData(null, "world", -1)]
+        [InlineData(null, null, 0)]
+        public void WithNull(string? x, string? y, int expected)
+        {
+            var compareOnLength = new MappedComparer<string, int>(x => x.Length);
+            Assert.Equal(expected, compareOnLength.Compare(x, y));
         }
     }
 }

--- a/test/Recore.Collections.Generic/MappedComparerTests.cs
+++ b/test/Recore.Collections.Generic/MappedComparerTests.cs
@@ -35,9 +35,9 @@ namespace Recore.Collections.Generic.Tests
 
             var equalityComparer = new AnonymousEqualityComparer<Person>(
                 (x, y) =>
-                    x.Id == y.Id
-                    && x.Name == y.Name
-                    && x.Age == y.Age,
+                    x?.Id == y?.Id
+                    && x?.Name == y?.Name
+                    && x?.Age == y?.Age,
                 x => HashCode.Combine(x.Name, x.Age));
 
             Assert.Equal(sortedPersons, persons, equalityComparer);

--- a/test/Recore.Collections.Generic/MappedEqualityComparerTests.cs
+++ b/test/Recore.Collections.Generic/MappedEqualityComparerTests.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
-using Recore.Collections.Generic;
 using Xunit;
 
-namespace Recore.Tests.Recore.Collections.Generic
+namespace Recore.Collections.Generic.Tests
 {
     public class MappedEqualityComparerTests
     {
@@ -40,6 +39,17 @@ namespace Recore.Tests.Recore.Collections.Generic
             var sameAge = new MappedEqualityComparer<Person, int>(x => x.Age);
             Assert.Equal(persons, morePersons, sameAge);
             Assert.NotEqual(persons, notEqual, sameAge);
+        }
+
+        [Theory]
+        [InlineData("hello", "world", true)]
+        [InlineData("hello", null, false)]
+        [InlineData(null, "world", false)]
+        [InlineData(null, null, true)]
+        public void WithNull(string? x, string? y, bool expected)
+        {
+            var compareOnLength = new MappedEqualityComparer<string, int>(x => x.Length);
+            Assert.Equal(expected, compareOnLength.Equals(x, y));
         }
     }
 }

--- a/test/Recore.Text.Json.Serialization.Converters/EitherConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/EitherConverterTests.cs
@@ -84,10 +84,10 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                 expected: new Either<string, int>("hello"),
                 actual: JsonSerializer.Deserialize<Either<string, int>>("\"hello\""));
 
-            var deserializedPerson = JsonSerializer.Deserialize<Either<Person, string>>("{\"Name\":\"Mario\",\"Age\":42}");
+            var deserializedPerson = JsonSerializer.Deserialize<Either<Person, string>>("{\"Name\":\"Mario\",\"Age\":42}")!;
             Assert.Equal(
                 expected: "Mario",
-                actual: deserializedPerson!.GetLeft().OnValue(x => x.Name));
+                actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
 
             Assert.Equal(
                 expected: 42,
@@ -109,7 +109,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
         public void FromJsonBothRecordTypesAlwaysDeserializesLeft()
         {
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
@@ -119,7 +119,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Age));
 
                 // This will deserialize as Person instead of Address because TLeft = Person.
-                var deserializedAddress = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}");
+                var deserializedAddress = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}")!;
                 Assert.True(deserializedAddress.IsLeft);
 
                 Assert.False(
@@ -135,7 +135,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
         public void FromJsonObjectTypesWithConverter()
         {
             { // This will always deserialize the left type because it is a POCO
-                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
@@ -144,7 +144,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Age));
 
-                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"fullName\":\"Alice X\",\"age\":28}");
+                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"fullName\":\"Alice X\",\"age\":28}")!;
                 Assert.True(deserializedTypeWithConverter.IsLeft);
 
                 Assert.False(
@@ -155,7 +155,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedTypeWithConverter.GetLeft().OnValue(x => x.Age));
             }
             { // This will try to convert with the left type, and then convert to the right type if it fails
-                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}");
+                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}")!;
                 Assert.Equal(
                     expected: "Alice",
                     actual: deserializedTypeWithConverter.GetLeft().OnValue(x => x.Name));
@@ -164,7 +164,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 28,
                     actual: deserializedTypeWithConverter.GetLeft().OnValue(x => x.Age));
 
-                var deserializedPerson = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetRight().OnValue(x => x.Name));
@@ -187,7 +187,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                 deserializeAsLeft: json => json.TryGetProperty("fullName", out JsonElement _)));
 
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}", options);
+                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}", options)!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
@@ -196,7 +196,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Age));
 
-                var deserializedAddress = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}", options);
+                var deserializedAddress = JsonSerializer.Deserialize<Either<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}", options)!;
                 Assert.Equal(
                     expected: "123 Main St",
                     actual: deserializedAddress.GetRight().OnValue(x => x.Street));
@@ -206,7 +206,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedAddress.GetRight().OnValue(x => x.Zip));
             }
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}", options);
+                var deserializedPerson = JsonSerializer.Deserialize<Either<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}", options)!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Name));
@@ -215,7 +215,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetLeft().OnValue(x => x.Age));
 
-                var deserializedAddress = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}", options);
+                var deserializedAddress = JsonSerializer.Deserialize<Either<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}", options)!;
                 Assert.Equal(
                     expected: "Alice",
                     actual: deserializedAddress.GetLeft().OnValue(x => x.Name));

--- a/test/Recore.Text.Json.Serialization.Converters/Internal/Types.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/Internal/Types.cs
@@ -43,6 +43,11 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
             reader.Read();
             var fullName = reader.GetString();
 
+            if (fullName is null)
+            {
+                throw new JsonException();
+            }
+
             reader.Read();
             propertyName = reader.GetString();
             if (propertyName != "age")
@@ -93,6 +98,11 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
 
             reader.Read();
             var value = reader.GetString();
+
+            if (value is null)
+            {
+                throw new JsonException();
+            }
 
             reader.Read();
             if (reader.GetString() != "length")

--- a/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
@@ -113,7 +113,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
             Assert.Equal(
                 expected: new JsonStreetAddress("1 Microsoft Way"),
                 actual: JsonSerializer
-                    .Deserialize<Of<string>>("\"1 Microsoft Way\"")
+                    .Deserialize<Of<string>>("\"1 Microsoft Way\"")!
                     .To<JsonStreetAddress>());
 
             Assert.Equal(
@@ -122,16 +122,16 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
 
             Assert.Equal(
                 expected: new JsonStreetAddress("123 Main St"),
-                actual: JsonSerializer.Deserialize<House>("{\"Street\":\"123 Main St\"}").Street);
+                actual: JsonSerializer.Deserialize<House>("{\"Street\":\"123 Main St\"}")!.Street);
 
-            var deserializedUser = JsonSerializer.Deserialize<User>("{\"Name\":\"Mario\",\"Age\":42}");
+            var deserializedUser = JsonSerializer.Deserialize<User>("{\"Name\":\"Mario\",\"Age\":42}")!;
             Assert.Equal(
                 expected: "Mario",
-                actual: deserializedUser.Value.Name);
+                actual: deserializedUser.Value?.Name);
 
             Assert.Equal(
                 expected: 42,
-                actual: deserializedUser.Value.Age);
+                actual: deserializedUser.Value?.Age);
         }
 
         [Fact]

--- a/test/Recore.Text.Json.Serialization.Converters/ResultConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/ResultConverterTests.cs
@@ -64,7 +64,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                 expected: new Result<string, int>("hello"),
                 actual: JsonSerializer.Deserialize<Result<string, int>>("\"hello\""));
 
-            var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Exception>>("{\"Name\":\"Mario\",\"Age\":42}");
+            var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Exception>>("{\"Name\":\"Mario\",\"Age\":42}")!;
             Assert.Equal(
                 expected: "Mario",
                 actual: deserializedPerson.GetValue().OnValue(x => x.Name));
@@ -89,7 +89,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
         public void FromJsonBothRecordTypesAlwaysDeserializesLeft()
         {
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetValue().OnValue(x => x.Name));
@@ -99,7 +99,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedPerson.GetValue().OnValue(x => x.Age));
 
                 // This will deserialize as Person instead of Address because TValue = Person.
-                var deserializedAddress = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}");
+                var deserializedAddress = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}")!;
                 Assert.True(deserializedAddress.IsSuccessful);
 
                 Assert.False(
@@ -115,7 +115,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
         public void FromJsonObjectTypesWithConverter()
         {
             { // This will always deserialize the left type because it is a POCO
-                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetValue().OnValue(x => x.Name));
@@ -124,7 +124,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetValue().OnValue(x => x.Age));
 
-                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"fullName\":\"Alice X\",\"age\":28}");
+                var deserializedTypeWithConverter = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"fullName\":\"Alice X\",\"age\":28}")!;
                 Assert.True(deserializedTypeWithConverter.IsSuccessful);
 
                 Assert.False(
@@ -135,7 +135,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedTypeWithConverter.GetValue().OnValue(x => x.Age));
             }
             { // This will try to convert with the left type, and then convert to the right type if it fails
-                var deserializedAddress = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}");
+                var deserializedAddress = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}")!;
                 Assert.Equal(
                     expected: "Alice",
                     actual: deserializedAddress.GetValue().OnValue(x => x.Name));
@@ -144,7 +144,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 28,
                     actual: deserializedAddress.GetValue().OnValue(x => x.Age));
 
-                var deserializedPerson = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"Name\":\"Mario\",\"Age\":42}");
+                var deserializedPerson = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"Name\":\"Mario\",\"Age\":42}")!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetError().OnValue(x => x.Name));
@@ -167,7 +167,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                 deserializeAsValue: json => json.TryGetProperty("fullName", out JsonElement _)));
 
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}", options);
+                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Name\":\"Mario\",\"Age\":42}", options)!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetValue().OnValue(x => x.Name));
@@ -176,7 +176,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetValue().OnValue(x => x.Age));
 
-                var deserializedAddress = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}", options);
+                var deserializedAddress = JsonSerializer.Deserialize<Result<Person, Address>>("{\"Street\":\"123 Main St\",\"Zip\":\"12345\"}", options)!;
                 Assert.Equal(
                     expected: "123 Main St",
                     actual: deserializedAddress.GetError().OnValue(x => x.Street));
@@ -186,7 +186,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     actual: deserializedAddress.GetError().OnValue(x => x.Zip));
             }
             {
-                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}", options);
+                var deserializedPerson = JsonSerializer.Deserialize<Result<Person, TypeWithConverter>>("{\"Name\":\"Mario\",\"Age\":42}", options)!;
                 Assert.Equal(
                     expected: "Mario",
                     actual: deserializedPerson.GetValue().OnValue(x => x.Name));
@@ -195,7 +195,7 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
                     expected: 42,
                     actual: deserializedPerson.GetValue().OnValue(x => x.Age));
 
-                var deserializedAddress = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}", options);
+                var deserializedAddress = JsonSerializer.Deserialize<Result<TypeWithConverter, Person>>("{\"fullName\":\"Alice X\",\"age\":28}", options)!;
                 Assert.Equal(
                     expected: "Alice",
                     actual: deserializedAddress.GetValue().OnValue(x => x.Name));

--- a/test/Recore/TokenTests.cs
+++ b/test/Recore/TokenTests.cs
@@ -65,6 +65,7 @@ namespace Recore.Tests
             var hello = new Token("hello");
             Assert.False(helloworld1.Equals(hello));
             Assert.False(hello.Equals(helloworld1));
+            Assert.False(helloworld1.Equals(null));
         }
 
         [Fact]
@@ -114,6 +115,8 @@ namespace Recore.Tests
             Assert.Equal(-1, new Token("abc").CompareTo(new Token("def")));
             Assert.Equal(0, new Token("abc").CompareTo(new Token("abc")));
             Assert.Equal(1, new Token("def").CompareTo(new Token("abc")));
+
+            Assert.Equal(1, new Token("abc").CompareTo(null));
         }
 
         [Fact]


### PR DESCRIPTION
v1 targeted .NET Standard 2.0.  I was originally planning having v2 target .NET Standard 2.1, but I think going right to .NET 5 is the move.  .NET 5 is set to be released in November of this year.

* .NET 5 adds `T?`, which lets you do nullable references in a lot more places with generics.  Of course, there's a lot of generics here.
* [This blog post](https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/) on the future of .NET Standard recommends going right to .NET 5:

> Most code can probably skip .NET Standard 2.1 and go straight to .NET 5

Upgrading to .NET 5 also exposed a bunch of nullability errors I wasn't getting before.  It probably has something to do with going from the attributes to `T?`.

Other changes:
* Fix potential NREs in `MappedComparer`, `MappedEqualityComparer`, and `Token`