### PR TITLE
Go back to the v1 GetLeft(), etc. signatures

### DIFF
--- a/src/Recore/Either.cs
+++ b/src/Recore/Either.cs
@@ -138,6 +138,22 @@ namespace Recore
         }
 
         /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TLeft&gt;</c>.
+        /// </summary>
+        public Optional<TLeft> GetLeft()
+            => Switch(
+                Optional.Of,
+                r => Optional<TLeft>.Empty);
+
+        /// <summary>
+        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TRight&gt;</c>.
+        /// </summary>
+        public Optional<TRight> GetRight()
+            => Switch(
+                l => Optional<TRight>.Empty,
+                Optional.Of);
+
+        /// <summary>
         /// Maps a function over the <see cref="Either{TLeft, TRight}"/> only if the value is an instance of <typeparamref name="TLeft"/>.
         /// </summary>
         public Either<TResult, TRight> OnLeft<TResult>(Func<TLeft, TResult> onLeft)
@@ -171,7 +187,7 @@ namespace Recore
 
         /// <summary>
         /// Converts this <see cref="Either{TLeft, TRight}"/>
-        /// to an <c>Either&lt;TRight, TLeft&gt;</c>
+        /// to an <c>Either&lt;TRight, TLeft&gt;</c>.
         /// </summary>
         public Either<TRight, TLeft> Swap()
             => Switch(
@@ -271,38 +287,6 @@ namespace Recore
     /// </summary>
     public static class Either
     {
-        /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}"/> to <see cref="Optional{T}">Optional&lt;TLeft&gt;</see>.
-        /// </summary>
-        public static Optional<TLeft> GetLeft<TLeft, TRight>(this Either<TLeft, TRight> either) where TLeft : notnull
-            => either.Switch(
-                Optional.Of,
-                r => Optional<TLeft>.Empty);
-
-        /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}">Either&lt;Nullable&lt;TLeft&gt;, TRight&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TLeft&gt;</see>.
-        /// </summary>
-        public static TLeft? GetLeft<TLeft, TRight>(this Either<TLeft?, TRight> either) where TLeft : struct
-            => either.Switch(
-                l => l,
-                r => null);
-
-        /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}"/> to <c cref="Optional{T}">Optional&lt;TRight&gt;</c>.
-        /// </summary>
-        public static Optional<TRight> GetRight<TLeft, TRight>(this Either<TLeft, TRight> either) where TRight : notnull
-            => either.Switch(
-                l => Optional<TRight>.Empty,
-                Optional.Of);
-
-        /// <summary>
-        /// Converts <see cref="Either{TLeft, TRight}">Either&lt;TLeft, Nullable&lt;TRight&gt;&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TRight&gt;</see>.
-        /// </summary>
-        public static TRight? GetRight<TLeft, TRight>(this Either<TLeft, TRight?> either) where TRight : struct
-            => either.Switch(
-                l => null,
-                r => r);
-
         /// <summary>
         /// Retrieves the value of an <see cref="Either{TLeft, TRight}"/> when <c>TLeft</c> and <c>TRight</c> are the same.
         /// </summary>

--- a/src/Recore/Result.cs
+++ b/src/Recore/Result.cs
@@ -93,6 +93,20 @@ namespace Recore
             => either.Switch(onValue, onError);
 
         /// <summary>
+        /// Converts <see cref="Result{TValue, TError}"/>
+        /// to <c cref="Optional{TValue}">Optional&lt;TValue&gt;</c>
+        /// </summary>
+        public Optional<TValue> GetValue()
+            => either.GetLeft();
+
+        /// <summary>
+        /// Converts <see cref="Result{TValue, TError}"/>
+        /// to <c cref="Optional{TError}">Optional&lt;TError&gt;</c>
+        /// </summary>
+        public Optional<TError> GetError()
+            => either.GetRight();
+
+        /// <summary>
         /// Maps a function over the <see cref="Result{TValue, TError}"/> only if the result is successful.
         /// </summary>
         public Result<TResult, TError> OnValue<TResult>(Func<TValue, TResult> onValue)
@@ -216,38 +230,6 @@ namespace Recore
         /// </summary>
         public static Result<TValue, TError> Failure<TValue, TError>(TError error)
             => new Result<TValue, TError>(error);
-
-        /// <summary>
-        /// Converts <see cref="Result{TValue, TError}"/> to <see cref="Optional{TValue}">Optional&lt;TValue&gt;</see>.
-        /// </summary>
-        public static Optional<TValue> GetValue<TValue, TError>(this Result<TValue, TError> either) where TValue : notnull
-            => either.Switch(
-                Optional.Of,
-                r => Optional<TValue>.Empty);
-
-        /// <summary>
-        /// Converts <see cref="Result{TValue, TError}">Result&lt;Nullable&lt;TValue&gt;, TError&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TValue&gt;</see>.
-        /// </summary>
-        public static TValue? GetValue<TValue, TError>(this Result<TValue?, TError> either) where TValue : struct
-            => either.Switch(
-                l => l,
-                r => null);
-
-        /// <summary>
-        /// Converts <see cref="Result{TValue, TError}"/> to <see cref="Optional{TError}">Optional&lt;TError&gt;</see>.
-        /// </summary>
-        public static Optional<TError> GetError<TValue, TError>(this Result<TValue, TError> either) where TError : notnull
-            => either.Switch(
-                l => Optional<TError>.Empty,
-                Optional.Of);
-
-        /// <summary>
-        /// Converts <see cref="Result{TValue, TError}">Result&lt;TValue, Nullable&lt;TError&gt;&gt;</see> to <see cref="Nullable{T}">Nullable&lt;TError&gt;</see>.
-        /// </summary>
-        public static TError? GetError<TValue, TError>(this Result<TValue, TError?> either) where TError : struct
-            => either.Switch(
-                l => null,
-                r => r);
 
         /// <summary>
         /// Wraps a function to be executed and converted to <see cref="Result{TValue, TError}"/>.

--- a/test/Recore/EitherTests.cs
+++ b/test/Recore/EitherTests.cs
@@ -347,11 +347,11 @@ namespace Recore.Tests
             Assert.False(left.GetRight().HasValue);
 
             left = new Either<int?, string>(left: null);
-            Assert.Null(left.GetLeft());
+            Assert.False(left.GetLeft().HasValue);
             Assert.False(left.GetRight().HasValue);
 
             var right = new Either<int?, string>("hello");
-            Assert.Null(right.GetLeft());
+            Assert.False(right.GetLeft().HasValue);
             Assert.Equal("hello", right.GetRight());
         }
 

--- a/test/Recore/ResultTests.cs
+++ b/test/Recore/ResultTests.cs
@@ -333,11 +333,11 @@ namespace Recore.Tests
             Assert.False(left.GetError().HasValue);
 
             left = new Result<int?, string>(value: null);
-            Assert.Null(left.GetValue());
+            Assert.False(left.GetValue().HasValue);
             Assert.False(left.GetError().HasValue);
 
             var right = new Result<int?, string>("hello");
-            Assert.Null(right.GetValue());
+            Assert.False(right.GetValue().HasValue);
             Assert.Equal("hello", right.GetError());
         }
 


### PR DESCRIPTION
Closes #163.

Seems like the `TLeft?` syntax won't produce `Nullable<T>` for a value type.  See https://github.com/recorefx/RecoreFX/issues/163#issuecomment-699190537 for more details.