### PR TITLE
Build with .NET 5.0 GA

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -9,13 +9,13 @@ trigger:
     - docs/*
 
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: ubuntu-latest
 
 steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: '5.0.100-rc.1.20452.10'
+    version: '5.0.100'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"

--- a/.azure/pipelines/docs.yml
+++ b/.azure/pipelines/docs.yml
@@ -9,7 +9,7 @@ steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
-      version: '5.0.100-rc.1.20452.10'
+      version: '5.0.100'
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - script: dotnet restore

--- a/.azure/pipelines/publish.yml
+++ b/.azure/pipelines/publish.yml
@@ -8,7 +8,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: '5.0.100-rc.1.20452.10'
+    version: '5.0.100'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet pack --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -12,7 +12,7 @@ jobs:
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-rc.1.20452.10'
+        dotnet-version: '5.0.100'
 
     - name: dotnet test
       run: dotnet test --configuration Release --logger trx --collect "XPlat code coverage"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/Recore.csproj
+++ b/src/Recore.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
     <RootNamespace>Recore</RootNamespace>
     <Version>2.0.0</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
@@ -10,7 +8,6 @@
     <PackageVersion>$(Version)-rc1</PackageVersion>
     <GenerateDocumentation>true</GenerateDocumentation>
     <DocumentationFile>bin/docs/Recore.xml</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Authors>Brian Cristante</Authors>
     <Company />
     <PackageId>RecoreFX</PackageId>
@@ -20,7 +17,6 @@
     <Product>RecoreFX</Product>
     <Copyright>Copyright (c) 2019 Brian Cristante</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Recore.csproj
+++ b/src/Recore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>Recore</RootNamespace>
     <Version>2.0.0</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>

--- a/test/Recore.Tests.csproj
+++ b/test/Recore.Tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Recore.Tests</RootNamespace>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/recorefx/RecoreFX/issues/182

- Use .NET 5.0 in CI
- Upgrade from C# 9.0 preview to GA
- Add `Directory.Build.props`

I also moved all VM images to the `-latest` tag.  This will keep the configurations from rotting.