### PR TITLE
Convert Ciphertext to a record type

### DIFF
--- a/docs/changelogs/v2.0.0.md
+++ b/docs/changelogs/v2.0.0.md
@@ -6,7 +6,7 @@
 - Removes `IReadOnlyDictionaryExtensions`, which contained two overloads of `GetValueOrDefault()`, preferring the [now-standard method](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions)
 - Also removes `IDictionaryExtensions.GetValueOrDefault<TKey, TValue>(Dictionary<TKey, TValue>, TKey)`, which is no longer needed to resolve ambiguity
 - `Of<T>.Value` is now init-only
-- `Token` is now a record type instead of a subtype of `Of<string>`
+- `Token` and `Ciphertext<THash>` are now record types instead of subtypes of `Of<string>`
 
 ## New features
 

--- a/src/Recore.Security.Cryptography/Ciphertext.cs
+++ b/src/Recore.Security.Cryptography/Ciphertext.cs
@@ -2,6 +2,9 @@
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Serialization;
+
+using Recore.Text.Json.Serialization.Converters;
 
 namespace Recore.Security.Cryptography
 {
@@ -14,17 +17,25 @@ namespace Recore.Security.Cryptography
     /// For example, if your application is storing users' passwords in a database,
     /// you could use this type for the .NET representation of the stored passwords.
     /// </remarks>
-    public sealed class Ciphertext<THash> : Of<string> where THash : HashAlgorithm
+    [JsonConverter(typeof(CiphertextConverter))]
+    public sealed record Ciphertext<THash> where THash : HashAlgorithm
     {
-        // For deserialization with System.Text.Json
-        private Ciphertext()
+        private readonly string value;
+
+        internal Ciphertext(string value)
         {
+            this.value = value;
         }
 
-        private Ciphertext(string value)
-        {
-            Value = value;
-        }
+        /// <summary>
+        /// Returns the underlying string value.
+        /// </summary>
+        public override string ToString() => value;
+
+        /// <summary>
+        /// Converts this instance to its underlying value.
+        /// </summary>
+        public static implicit operator string(Ciphertext<THash> t) => t.ToString();
 
         /// <summary>
         /// Hashes a plaintext string to create an instance of <see cref="Ciphertext{THash}"/>.

--- a/src/Recore.Text.Json.Serialization.Converters/CiphertextConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/CiphertextConverter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Recore.Security.Cryptography;
+
+namespace Recore.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// JSON converter factory for the open generic type <seealso cref="CiphertextConverter{THash}"/>.
+    /// </summary>
+    internal sealed class CiphertextConverter : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert.IsGenericType
+            && typeToConvert.GetGenericTypeDefinition() == typeof(Ciphertext<>);
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var innerType = typeToConvert.GetGenericArguments()[0];
+
+            var converter = Activator.CreateInstance(
+                type: typeof(CiphertextConverter<>).MakeGenericType(new[] { innerType }));
+
+            if (converter is null)
+            {
+                // According to the docs, `CreateInstance` should return `null`
+                // only if the type is some `Nullable<T>`
+                throw new InvalidOperationException();
+            }
+
+            return (JsonConverter)converter;
+        }
+    }
+
+    /// <summary>
+    /// JSON converter for the generic type <seealso cref="CiphertextConverter{THash}"/>
+    /// for a given <typeparamref name="THash"/>.
+    /// </summary>
+    internal sealed class CiphertextConverter<THash> : JsonConverter<Ciphertext<THash>> where THash : HashAlgorithm
+    {
+        public override Ciphertext<THash> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string path = reader.GetString() ?? throw new JsonException();
+            return new Ciphertext<THash>(path);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Ciphertext<THash> value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/src/Recore.Text.Json.Serialization.Converters/EitherConverter.cs
+++ b/src/Recore.Text.Json.Serialization.Converters/EitherConverter.cs
@@ -34,7 +34,7 @@ namespace Recore.Text.Json.Serialization.Converters
 
     /// <summary>
     /// JSON converter for the generic type <seealso cref="Either{TLeft, TRight}"/>
-    /// for given <typeparamref name="TLeft"/> and <typeparamref name="TRight"/>.
+    /// for a given <typeparamref name="TLeft"/> and <typeparamref name="TRight"/>.
     /// </summary>
     internal sealed class EitherConverter<TLeft, TRight> : JsonConverter<Either<TLeft, TRight>>
     {

--- a/test/Recore.Security.Cryptography/CiphertextTests.cs
+++ b/test/Recore.Security.Cryptography/CiphertextTests.cs
@@ -12,17 +12,15 @@ namespace Recore.Security.Cryptography.Tests
         [Fact]
         public void ThrowsOnNull()
         {
-            using (var sha256 = SHA256.Create())
-            {
-                Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt(null!, Array.Empty<byte>(), sha256));
+            using var sha256 = SHA256.Create();
+            Assert.Throws<ArgumentNullException>(
+                () => Ciphertext<SHA256>.Encrypt(null!, Array.Empty<byte>(), sha256));
 
-                Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt("hello", null!, sha256));
+            Assert.Throws<ArgumentNullException>(
+                () => Ciphertext<SHA256>.Encrypt("hello", null!, sha256));
 
-                Assert.Throws<ArgumentNullException>(
-                    () => Ciphertext<SHA256>.Encrypt("hello", Array.Empty<byte>(), null!));
-            }
+            Assert.Throws<ArgumentNullException>(
+                () => Ciphertext<SHA256>.Encrypt("hello", Array.Empty<byte>(), null!));
         }
 
         // With this test, it's ok to use the short forms in the rest of the tests.
@@ -35,8 +33,8 @@ namespace Recore.Security.Cryptography.Tests
                 var inferAlgo = Ciphertext.Encrypt("hello", Array.Empty<byte>(), md5);
                 var shortForm = Ciphertext.MD5("hello", Array.Empty<byte>());
 
-                Assert.Equal(longForm.Value, inferAlgo.Value);
-                Assert.Equal(longForm.Value, shortForm.Value);
+                Assert.Equal(longForm, inferAlgo);
+                Assert.Equal(longForm, shortForm);
             }
 
             using (var sha1 = SHA1.Create())
@@ -45,8 +43,8 @@ namespace Recore.Security.Cryptography.Tests
                 var inferAlgo = Ciphertext.Encrypt("hello", Array.Empty<byte>(), sha1);
                 var shortForm = Ciphertext.SHA1("hello", Array.Empty<byte>());
 
-                Assert.Equal(longForm.Value, inferAlgo.Value);
-                Assert.Equal(longForm.Value, shortForm.Value);
+                Assert.Equal(longForm, inferAlgo);
+                Assert.Equal(longForm, shortForm);
             }
 
             using (var sha256 = SHA256.Create())
@@ -55,8 +53,8 @@ namespace Recore.Security.Cryptography.Tests
                 var inferAlgo = Ciphertext.Encrypt("hello", Array.Empty<byte>(), sha256);
                 var shortForm = Ciphertext.SHA256("hello", Array.Empty<byte>());
 
-                Assert.Equal(longForm.Value, inferAlgo.Value);
-                Assert.Equal(longForm.Value, shortForm.Value);
+                Assert.Equal(longForm, inferAlgo);
+                Assert.Equal(longForm, shortForm);
             }
         }
 
@@ -70,7 +68,7 @@ namespace Recore.Security.Cryptography.Tests
                 // This ciphertext was computed with the Bash command
                 // printf "hello" | md5sum | awk '{print $1}' | xxd -r -p | base64
                 var expected = "XUFAKrxLKna5cZ2REBfFkg==";
-                Assert.Equal(expected, ciphertext.Value);
+                Assert.Equal(expected, ciphertext);
             }
 
             using (var sha1 = SHA1.Create())
@@ -80,7 +78,7 @@ namespace Recore.Security.Cryptography.Tests
                 // This ciphertext was computed with the Bash command
                 // printf "hello" | sha1sum | awk '{print $1}' | xxd -r -p | base64
                 var expected = "qvTGHdzF6KLavt4PO0gs2a6pQ00=";
-                Assert.Equal(expected, ciphertext.Value);
+                Assert.Equal(expected, ciphertext);
             }
 
             using (var sha256 = SHA256.Create())
@@ -90,19 +88,8 @@ namespace Recore.Security.Cryptography.Tests
                 // This ciphertext was computed with the Bash command
                 // printf "hello" | sha256sum | awk '{print $1}' | xxd -r -p | base64
                 var expected = "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
-                Assert.Equal(expected, ciphertext.Value);
+                Assert.Equal(expected, ciphertext);
             }
-        }
-
-        [Fact]
-        public void GetHashCode_()
-        {
-            var ciphertext = Ciphertext.SHA256("hello", Array.Empty<byte>());
-
-            // This ciphertext was computed with the Bash command
-            // printf "hello" | sha256sum | awk '{print $1}' | xxd -r -p | base64
-            var expected = "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
-            Assert.Equal(expected.GetHashCode(), ciphertext.GetHashCode());
         }
 
         [Fact]
@@ -140,12 +127,10 @@ namespace Recore.Security.Cryptography.Tests
                 return true;
             }
 
-            using (var md5 = MD5.Create())
-            {
-                var longForm = Ciphertext<MD5>.Encrypt(plaintext, salt, md5);
-                var shortForm = Ciphertext.MD5(plaintext, salt);
-                return longForm == shortForm;
-            }
+            using var md5 = MD5.Create();
+            var longForm = Ciphertext<MD5>.Encrypt(plaintext, salt, md5);
+            var shortForm = Ciphertext.MD5(plaintext, salt);
+            return longForm == shortForm;
         }
 
         [Property]
@@ -157,12 +142,10 @@ namespace Recore.Security.Cryptography.Tests
                 return true;
             }
 
-            using (var sha1 = SHA1.Create())
-            {
-                var longForm = Ciphertext<SHA1>.Encrypt(plaintext, salt, sha1);
-                var shortForm = Ciphertext.SHA1(plaintext, salt);
-                return longForm == shortForm;
-            }
+            using var sha1 = SHA1.Create();
+            var longForm = Ciphertext<SHA1>.Encrypt(plaintext, salt, sha1);
+            var shortForm = Ciphertext.SHA1(plaintext, salt);
+            return longForm == shortForm;
         }
 
         [Property]
@@ -174,12 +157,10 @@ namespace Recore.Security.Cryptography.Tests
                 return true;
             }
 
-            using (var sha256 = SHA256.Create())
-            {
-                var longForm = Ciphertext<SHA256>.Encrypt(plaintext, salt, sha256);
-                var shortForm = Ciphertext.SHA256(plaintext, salt);
-                return longForm == shortForm;
-            }
+            using var sha256 = SHA256.Create();
+            var longForm = Ciphertext<SHA256>.Encrypt(plaintext, salt, sha256);
+            var shortForm = Ciphertext.SHA256(plaintext, salt);
+            return longForm == shortForm;
         }
 
         [Property]
@@ -196,6 +177,41 @@ namespace Recore.Security.Cryptography.Tests
             var unsalted = Ciphertext.SHA256(plaintext, Array.Empty<byte>());
             var salted = Ciphertext.SHA256(plaintext, salt);
             return unsalted != salted;
+        }
+
+        [Property]
+        public void EqualObjectsHaveEqualHashcodes(string plaintext)
+        {
+            if (plaintext is null)
+            {
+                return;
+            }
+
+            var ciphertext1 = Ciphertext.SHA256(plaintext, Array.Empty<byte>());
+            var ciphertext2 = Ciphertext.SHA256(plaintext, Array.Empty<byte>());
+
+            Assert.Equal(ciphertext1, ciphertext2);
+            Assert.Equal(ciphertext1.GetHashCode(), ciphertext2.GetHashCode());
+        }
+
+        [Property]
+        public void UnequalObjectsHaveUnequalHashcodes(string plaintext1, string plaintext2)
+        {
+            if (plaintext1 is null || plaintext2 is null)
+            {
+                return;
+            }
+
+            if (plaintext1 == plaintext2)
+            {
+                return;
+            }
+
+            var ciphertext1 = Ciphertext.SHA256(plaintext1, Array.Empty<byte>());
+            var ciphertext2 = Ciphertext.SHA256(plaintext2, Array.Empty<byte>());
+
+            Assert.NotEqual(ciphertext1, ciphertext2);
+            Assert.NotEqual(ciphertext1.GetHashCode(), ciphertext2.GetHashCode());
         }
     }
 }

--- a/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
+++ b/test/Recore.Text.Json.Serialization.Converters/OfConverterTests.cs
@@ -43,7 +43,6 @@ namespace Recore.Text.Json.Serialization.Converters.Tests
             Assert.True(factory.CanConvert(typeof(Of<int>)));
             Assert.True(factory.CanConvert(typeof(Of<SomeEnum>)));
             Assert.True(factory.CanConvert(typeof(Of<Of<object>>)));
-            Assert.True(factory.CanConvert(typeof(Ciphertext<SHA1>)));
             Assert.True(factory.CanConvert(typeof(DerivedOfString)));
             Assert.True(factory.CanConvert(typeof(DerivedDerivedOfString)));
 


### PR DESCRIPTION
Same reason as with `Token` (#186): `Of<T>.Value` is nullable.