### PR TITLE
Add Action overloads of Apply()

### DIFF
--- a/src/Recore/ObjectExtensions.cs
+++ b/src/Recore/ObjectExtensions.cs
@@ -32,7 +32,20 @@ namespace Recore
         }
 
         /// <summary>
-        /// Invokes an asynchronous function on a task.
+        /// Invokes an action on an object and passes the object through.
+        /// </summary>
+        public static T Apply<T>(this T obj, Action<T> action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            return obj.Apply(action.Fluent());
+        }
+
+        /// <summary>
+        /// Awaits a task and invokes an asynchronous function on a task.
         /// </summary>
         public static async Task<U> ApplyAsync<T, U>(this Task<T> task, AsyncFunc<T, U> func)
         {
@@ -42,6 +55,21 @@ namespace Recore
             }
 
             return await func(await task);
+        }
+
+        /// <summary>
+        /// Awaits a task, invokes an asynchronous action on the result, and passes the awaited task through.
+        /// </summary>
+        public static async Task<T> ApplyAsync<T>(this Task<T> task, AsyncAction<T> action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var result = await task;
+            await action(result);
+            return result;
         }
     }
 }

--- a/test/Recore/ObjectExtensionsTests.cs
+++ b/test/Recore/ObjectExtensionsTests.cs
@@ -22,14 +22,14 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public void Apply_ThrowsOnNull()
+        public void ApplyFunc_ThrowsOnNull()
         {
             Func<string, int> func = null!;
             Assert.Throws<ArgumentNullException>(() => "hello".Apply(func));
         }
 
         [Fact]
-        public void Apply()
+        public void ApplyFunc()
         {
             var result = "hello"
                 .Apply(x => x.Length)
@@ -39,7 +39,7 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public async Task Apply_Task()
+        public async Task ApplyFunc_Task()
         {
             var result = await "hello"
                 .Apply(x => Task.FromResult(x.Length))
@@ -49,7 +49,24 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public async Task ApplyAsync_ThrowsOnNull()
+        public void ApplyAction_ThrowsOnNull()
+        {
+            Action<string> action = null!;
+            Assert.Throws<ArgumentNullException>(() => "hello".Apply(action));
+        }
+
+        [Fact]
+        public void ApplyAction()
+        {
+            bool called = false;
+            var result = "hello"
+                .Apply(_ => { called = true; });
+
+            Assert.True(called);
+        }
+
+        [Fact]
+        public async Task ApplyAsyncFunc_ThrowsOnNull()
         {
             AsyncFunc<string, int> func = null!;
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
@@ -59,13 +76,37 @@ namespace Recore.Tests
         }
 
         [Fact]
-        public async Task ApplyAsync()
+        public async Task ApplyAsyncFunc()
         {
             var result = await "hello"
                 .Apply(x => Task.FromResult(x.Length))
                 .ApplyAsync(IsEvenAsync);
 
             Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ApplyAsyncAction_ThrowsOnNull()
+        {
+            AsyncAction<string> action = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await Task.FromResult("hello").ApplyAsync(action);
+            });
+        }
+
+        [Fact]
+        public async Task ApplyAsyncAction()
+        {
+            bool called = false;
+            var result = await Task.FromResult("hello")
+                .ApplyAsync(_ =>
+                {
+                    called = true;
+                    return Task.CompletedTask;
+                });
+
+            Assert.True(called);
         }
 
         private static bool IsEven(int n) => n % 2 == 0;


### PR DESCRIPTION
Calling `Func.Fluent()` won't really work named functions and methods, so it's a lot nicer just to have these overloads.